### PR TITLE
Add design doc for model deployment pipeline

### DIFF
--- a/docs/deployment-design.md
+++ b/docs/deployment-design.md
@@ -17,7 +17,6 @@ This process has the advantage of being simple, easy to maintain, and cheap; as 
 * Our on-prem server only has enough resources to run one model at a time, so only one data scientist may be running modeling experiments at a given time
   * Further, our server has no notion of a job queue, so a data scientist who is waiting to run a model must notice that a previous run has completed and initiate their run manually 
 * Our on-prem server does not have a GPU, so it can't make use of GPU-accelerated libraries like XGBoost
-* Our DVC configuration has disabled caching of intermediate outputs, so model runs must always begin from the start of the pipeline, saving on storage but increasing execution time as a result
 * Model runs are decoupled from changes to code and data in version control, so data scientists have to remember to commit their changes correctly
 * Results of model runs are not easily accessible to PR reviewers
 
@@ -47,7 +46,6 @@ Here is a rough sketch of a new model deployment pipeline:
 * Define a job, `build-docker-image`, to build and push a new Docker image for the model code to GitHub Container Registry
   * Cache the build using `renv.lock` as the key
 * Define a job to run the model (implementation details in the following sections)
-* Print a link to S3 model evaluation outputs that will be visible in the GitHub Actions UI
  
 See the following sections for two options for how we can run the model itself.
 
@@ -73,14 +71,21 @@ If CML does not work as advertised, we can always implement our own version of i
 * Use the AWS CLI to [submit a job](https://docs.aws.amazon.com/cli/latest/reference/batch/submit-job.html) to the Batch queue
 * Use the AWS CLI to [poll the job status](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/batch/describe-jobs.html) until it has a terminal status (`SUCCEEDED` or `FAILED`)
   * Once the job has at least a `RUNNING` status, use the `jobStreamName` parameter to print a link to its logs
+ 
+### Reporting model performance
+
+We would like to move toward the following pattern for evaluating model performance:
+
+1. Use an Quarto doc stored in the repo to analyze/diagnose/display single model performance. This will be created for each model run and will be sent as a link in the SNS notification at the end of a run.
+2. Use Tableau for cross-model comparison, using the same dashboards as previous years.
+
+Step 1 will require us to update `05-finalize.R` to generate the Quarto doc, upload it to S3, and adjust the SNS message body to include a link to it.
 
 ### Caching intermediate data
 
 Caching intermediate data would allow us to only run model stages whose code, data, or dependencies have changed since the last model run. This has the potential to reduce the amount of compute we use and speed up experimentation.
 
-Remote caching is currently [not natively supported by DVC](https://github.com/iterative/dvc/issues/5665#issuecomment-811087810), but it should be possible if we pull the [cache directory](https://dvc.org/doc/user-guide/project-structure/internal-files#structure-of-the-cache-directory) from S3 storage before each run and push it after successful runs. All branches should have their own cache, but PR branches should inherit the main branch cache before their first successful run. Note that to enable this caching, we would also need to remove the `cache: false` attribute that is currently set on all of our intermediate outputs. We would also need to start saving `.dvc` metadata files under version control so that model runs know which version of the data to pull.
-
-We should consider this step to be an iterative improvement on the pipeline MVP, since it's not required to run the model and it may introduce more complexity than the reduction in runtime is worth.
+Remote caching is currently [not natively supported by DVC](https://github.com/iterative/dvc/issues/5665#issuecomment-811087810), but it is theoreitcally possible if we were to pull the [cache directory](https://dvc.org/doc/user-guide/project-structure/internal-files#structure-of-the-cache-directory) from S3 storage before each run and push it after successful runs. However, this pattern would also require updating the `dvc.lock` file on every run, so it's likely too fragile to be worth implementing right now.
 
 ### Metrics and experiments
 
@@ -94,4 +99,4 @@ We will create GitHub issues for the following tasks:
 * Add GitHub workflow to deploy and run the model on commits to PRs
    * Note that there is a prototype of a similar workflow [on GitLab](https://gitlab.com/ccao-data-science---modeling/models/ccao_res_avm/-/blob/master/.gitlab-ci.yml?ref_type=heads) that may be useful
    * Spike the CML self-hosted runner solution first, and move on to the custom solution if CML runners don't work as advertised
-* Time permitting: Add workflow cache for intermediate data
+* Update the Finalize step to generate a Quarto doc and link to it in SNS notification

--- a/docs/deployment-design.md
+++ b/docs/deployment-design.md
@@ -46,10 +46,12 @@ Here is a rough sketch of a new model deployment pipeline:
 * Use the AWS CLI to [submit a job](https://docs.aws.amazon.com/cli/latest/reference/batch/submit-job.html) to the Batch queue
 * Use the AWS CLI to [poll the job status](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/batch/describe-jobs.html) until it has a terminal status (`SUCCEEDED` or `FAILED`)
   * Once the job has at least a `RUNNING` status, use the `jobStreamName` parameter to print a link to its logs
-* _TK: Output?_
+* _TK: How should we format output for pushing back to the PR? Is it enough to push the results doc to S3 and print a link in the workflow output, or do we need an integration that can actually post a comment on the PR, à la Codecov?_
 
 ## Tasks
 
+We will create GitHub issues for the following tasks:
+
 * Add Docker image definition for the model
 * Add GitHub workflow to deploy and run an AWS Batch job on commits to PRs
-* _TK: Show better output?_
+* _TK: Output reporting improvements?_

--- a/docs/deployment-design.md
+++ b/docs/deployment-design.md
@@ -1,0 +1,34 @@
+# Design doc: Model deployment pipeline
+
+This doc represents a proposal for a CI/CD pipeline for running our residential model.
+
+## Requirements
+
+At a high level, a model deployment pipeline must:
+
+* Integrate with our cloud tools (GitHub and AWS)
+* Trigger model runs from pull request branches
+* Run the model on ephemeral, cheap, and isolated cloud infrastructure
+* Report model statistics back to the pull request branch that triggered a run
+
+## Design
+
+Adapted from: https://aws.amazon.com/blogs/opensource/github-actions-aws-fargate
+
+* Define a new workflow, `run-model.yaml`, that runs on:
+  * Every commit to every pull request against the main branch
+  * `workflow_dispatch`
+* Set up the workflow so that it deploys to the `staging` environment and requires [manual approval](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#using-environments-to-manually-trigger-workflow-jobs)
+* Use the [`configure-aws-credentials`](https://github.com/aws-actions/configure-aws-credentials) action to authenticate with AWS
+* Build and push a new docker image to ECR
+* Run Terraform to make sure an AWS Batch job queue and job definition exist for the PR
+* Use the AWS CLI to [submit a job](https://docs.aws.amazon.com/cli/latest/reference/batch/submit-job.html) to the Batch queue
+* Use the AWS CLI to [poll the job status](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/batch/describe-jobs.html) until it has a terminal status (`SUCCEEDED` or `FAILED`)
+  * Once the job has at least a `RUNNING` status, use the `jobStreamName` parameter to print a link to its logs
+* TK: Output?
+
+## Tasks
+
+* Add container image definition for the model
+* Add GitHub workflow to deploy and run an AWS Batch job on commits to PRs
+* TK: Show better output?

--- a/docs/deployment-design.md
+++ b/docs/deployment-design.md
@@ -1,34 +1,55 @@
 # Design doc: Model deployment pipeline
 
-This doc represents a proposal for a CI/CD pipeline for running our residential model.
+This doc represents a proposal for a simple CI/CD pipeline that we can use to deploy residential models and run experiments on them.
+
+## Background
+
+At a high level, our **existing process** for experimenting with changes to our models looks like this:
+
+* Models run on an on-prem server
+* Data scientists trigger model runs by SSHing into the server and running shell commands from cloned copies of this repo
+* Model artifacts are saved using DVC
+* Data scientists commit corresponding changes to model code after their experiment runs prove successful  
+
+This process has the advantage of being simple, easy to maintain, and cheap; as a result it has been useful to our team during the recent past when we only had a few data scientists on staff and they needed to focus most of their effort on building a new model from the ground up. However, some of its **limitations** are becoming apparent as our team scales up and begins to expand our focus:
+
+* Our on-prem server only has enough resources to run one model at a time, so only one data scientist may be running modeling experiments at a given time
+  * Further, our server has no notion of a job queue, so a data scientist who is waiting to run a model must notice that a previous run has completed and initiate their run manually 
+* Our on-prem server does not have a GPU, so it can't make use of GPU-accelerated libraries like XGBoost
+* Model runs are decoupled from version control changes, so data scientists have to remember to commit their changes correctly
+* Results of model runs are not easily accessible to PR reviewers
+
+The design described below aims to remove these limitations while retaining as much simplicity, maintainability, and affordability as possible.
 
 ## Requirements
 
-At a high level, a model deployment pipeline must:
+At a high level, a model deployment pipeline should:
 
-* Integrate with our cloud tools (GitHub and AWS)
+* Integrate with our existing cloud infrastructure (GitHub and AWS)
 * Trigger model runs from pull request branches
+* Require code authors to approve model runs before they are initiated
 * Run the model on ephemeral, cheap, and isolated cloud infrastructure
-* Report model statistics back to the pull request branch that triggered a run
+* Run multiple model runs simultaneously on separate hardware
+* Report model statistics back to the pull request that triggered a run
 
 ## Design
 
-Adapted from: https://aws.amazon.com/blogs/opensource/github-actions-aws-fargate
+Here is a rough sketch of a new model deployment pipeline:
 
 * Define a new workflow, `run-model.yaml`, that runs on:
   * Every commit to every pull request against the main branch
-  * `workflow_dispatch`
+  * The `workflow_dispatch` event
 * Set up the workflow so that it deploys to the `staging` environment and requires [manual approval](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#using-environments-to-manually-trigger-workflow-jobs)
 * Use the [`configure-aws-credentials`](https://github.com/aws-actions/configure-aws-credentials) action to authenticate with AWS
-* Build and push a new docker image to ECR
 * Run Terraform to make sure an AWS Batch job queue and job definition exist for the PR
+* Build and push a new Docker image to ECR
 * Use the AWS CLI to [submit a job](https://docs.aws.amazon.com/cli/latest/reference/batch/submit-job.html) to the Batch queue
 * Use the AWS CLI to [poll the job status](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/batch/describe-jobs.html) until it has a terminal status (`SUCCEEDED` or `FAILED`)
   * Once the job has at least a `RUNNING` status, use the `jobStreamName` parameter to print a link to its logs
-* TK: Output?
+* _TK: Output?_
 
 ## Tasks
 
-* Add container image definition for the model
+* Add Docker image definition for the model
 * Add GitHub workflow to deploy and run an AWS Batch job on commits to PRs
-* TK: Show better output?
+* _TK: Show better output?_


### PR DESCRIPTION
This PR adds a draft of a design doc proposing we build a new deployment pipeline to allow us to run models on [AWS Batch](https://aws.amazon.com/batch/), triggered by a GitHub Actions workflow either manually or via a PR.

The design as currently proposed is simple enough that I don't think it's worth pulling this PR in; rather, I'm opening it for the purposes of discussion, and once the design is approved and we begin work we can make sure that the final design is documented in the README of this repo whenever we do the implementation work.