### PR TITLE
Add dispatchable workflow for deleting test model runs

### DIFF
--- a/.github/workflows/delete-model-runs.yaml
+++ b/.github/workflows/delete-model-runs.yaml
@@ -1,8 +1,8 @@
 # Workflow that can be manually dispatched to delete test model runs that
 # do not need to be persisted indefinitely.
 #
-# Gated such that it's impossible to delete runs older than the current upcoming
-# assessment cycle.
+# Gated such that it's impossible to delete runs older than the current
+# assessment cycle, where each assessment cycle starts in April.
 
 name: delete-model-runs
 
@@ -26,8 +26,8 @@ jobs:
           use-public-rspm: true
 
       - name: Install system dependencies
-        # TODO: Cache this step
         run: sudo apt-get install libgit2-dev
+        shell: bash
 
       - name: Setup renv
         uses: r-lib/actions/setup-renv@v2
@@ -35,8 +35,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          # TODO: Create a new role and add it to repo secrets
-          role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE_MODEL_DELETION_ARN }}
           aws-region: us-east-1
 
       - name: Delete model runs
@@ -46,4 +45,4 @@ jobs:
           done
         shell: bash
         env:
-          RUN_IDS: 1,2,3,4,5
+          RUN_IDS: 2023-11-14-frosty-jacob

--- a/.github/workflows/delete-model-runs.yaml
+++ b/.github/workflows/delete-model-runs.yaml
@@ -29,6 +29,10 @@ jobs:
         run: sudo apt-get install libgit2-dev
         shell: bash
 
+      - name: Disable renv sandbox to speed up install time
+        run: echo "RENV_CONFIG_SANDBOX_ENABLED=FALSE" >> .Renviron
+        shell: bash
+
       - name: Setup renv
         uses: r-lib/actions/setup-renv@v2
 

--- a/.github/workflows/delete-model-runs.yaml
+++ b/.github/workflows/delete-model-runs.yaml
@@ -7,16 +7,7 @@
 name: delete-model-runs
 
 on:
-  workflow_dispatch:
-    inputs:
-      run-ids:
-        description: >
-          Comma-delimited list of IDs of model runs to delete. Note that the
-          workflow assumes these IDs correspond to model runs for the current
-          upcoming assessment cycle, and if that's not the case the deletion
-          script will raise an error.
-        required: true
-        type: string
+  pull_request:
 
 jobs:
   delete-model-runs:
@@ -54,4 +45,4 @@ jobs:
           done
         shell: bash
         env:
-          RUN_IDS: ${{ inputs.run-ids }}
+          RUN_IDS: 2023-11-14-frosty-jacob

--- a/.github/workflows/delete-model-runs.yaml
+++ b/.github/workflows/delete-model-runs.yaml
@@ -45,4 +45,4 @@ jobs:
           done
         shell: bash
         env:
-          RUN_IDS: 2023-11-14-frosty-jacob
+          RUN_IDS: 2024-11-14-foo-bar

--- a/.github/workflows/delete-model-runs.yaml
+++ b/.github/workflows/delete-model-runs.yaml
@@ -25,6 +25,10 @@ jobs:
         with:
           use-public-rspm: true
 
+      - name: Install system dependencies
+        # TODO: Cache this step
+        run: sudo apt-get install libgit2-dev
+
       - name: Setup renv
         uses: r-lib/actions/setup-renv@v2
 

--- a/.github/workflows/delete-model-runs.yaml
+++ b/.github/workflows/delete-model-runs.yaml
@@ -1,0 +1,54 @@
+# Workflow that can be manually dispatched to delete test model runs that
+# do not need to be persisted indefinitely.
+#
+# Gated such that it's impossible to delete runs older than the current upcoming
+# assessment cycle.
+
+name: delete-model-runs
+
+on:
+  workflow_dispatch:
+    inputs:
+      run-ids:
+        description: >
+          Comma-delimited list of IDs of model runs to delete. Note that the
+          workflow assumes these IDs correspond to model runs for the current
+          upcoming assessment cycle, and if that's not the case the deletion
+          script will raise an error.
+        required: true
+        type: string
+
+jobs:
+  delete-model-runs:
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to interact with GitHub's OIDC Token endpoint so we can auth AWS
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repo code
+        uses: actions/checkout@v4
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Setup renv
+        uses: r-lib/actions/setup-renv@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          # TODO: Create a new role and add it to repo secrets
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE_MODEL_DELETION_ARN }}
+          aws-region: us-east-1
+
+      - name: Delete model runs
+        run: |
+          for run_id in ${RUN_IDS//,/}; do
+            Rscript ./R/delete_current_year_model_runs.R "$run_id"
+          done
+        shell: bash
+        env:
+          RUN_IDS: ${{ inputs.run-ids }}

--- a/.github/workflows/delete-model-runs.yaml
+++ b/.github/workflows/delete-model-runs.yaml
@@ -7,17 +7,7 @@
 name: delete-model-runs
 
 on:
-  workflow_dispatch:
-    inputs:
-      run-ids:
-        description: >
-          Run IDs: Space-delimited list of IDs of model runs to delete. Note
-          that the workflow assumes these IDs correspond to model runs for the
-          current assessment cycle, and if that's not the case the deletion
-          script will raise an error.
-        required: true
-        type: string
-        default: 2024-01-01-foo-bar 2024-01-02-bar-baz
+  pull_request:
 
 jobs:
   delete-model-runs:
@@ -56,4 +46,4 @@ jobs:
         run: Rscript ./R/delete_current_year_model_runs.R "${RUN_IDS// /,}"
         shell: bash
         env:
-          RUN_IDS: ${{ inputs.run-ids }}
+          RUN_IDS: 2024-01-01-foo-bar 2024-01-02-bar-baz

--- a/.github/workflows/delete-model-runs.yaml
+++ b/.github/workflows/delete-model-runs.yaml
@@ -7,7 +7,16 @@
 name: delete-model-runs
 
 on:
-  pull_request:
+  workflow_dispatch:
+    inputs:
+      run-ids:
+        description: >
+          Comma-delimited list of IDs of model runs to delete. Note that the
+          workflow assumes these IDs correspond to model runs for the current
+          upcoming assessment cycle, and if that's not the case the deletion
+          script will raise an error.
+        required: true
+        type: string
 
 jobs:
   delete-model-runs:
@@ -45,4 +54,4 @@ jobs:
           done
         shell: bash
         env:
-          RUN_IDS: 2023-11-14-frosty-jacob
+          RUN_IDS: ${{ inputs.run-ids }}

--- a/.github/workflows/delete-model-runs.yaml
+++ b/.github/workflows/delete-model-runs.yaml
@@ -46,4 +46,4 @@ jobs:
         run: Rscript ./R/delete_current_year_model_runs.R "$RUN_IDS"
         shell: bash
         env:
-          RUN_IDS: 2024-11-14-foo-bar,2024-11-15-baz
+          RUN_IDS: 2023-11-14-frosty-jacob,2024-11-15-baz

--- a/.github/workflows/delete-model-runs.yaml
+++ b/.github/workflows/delete-model-runs.yaml
@@ -43,10 +43,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Delete model runs
-        run: |
-          for run_id in ${RUN_IDS//,/ }; do
-            Rscript ./R/delete_current_year_model_runs.R "$run_id"
-          done
+        run: Rscript ./R/delete_current_year_model_runs.R "$RUN_IDS"
         shell: bash
         env:
           RUN_IDS: 2024-11-14-foo-bar

--- a/.github/workflows/delete-model-runs.yaml
+++ b/.github/workflows/delete-model-runs.yaml
@@ -7,7 +7,16 @@
 name: delete-model-runs
 
 on:
-  pull_request:
+  workflow_dispatch:
+    inputs:
+      run-ids:
+        description: >
+          Comma-delimited list of IDs of model runs to delete (no spaces). Note
+          that the workflow assumes these IDs correspond to model runs for the
+          current upcoming assessment cycle, and if that's not the case the
+          deletion script will raise an error.
+        required: true
+        type: string
 
 jobs:
   delete-model-runs:
@@ -46,4 +55,4 @@ jobs:
         run: Rscript ./R/delete_current_year_model_runs.R "$RUN_IDS"
         shell: bash
         env:
-          RUN_IDS: 2023-11-14-frosty-jacob,2023-11-13-stupefied-liz
+          RUN_IDS: ${{ inputs.run-ids }}

--- a/.github/workflows/delete-model-runs.yaml
+++ b/.github/workflows/delete-model-runs.yaml
@@ -11,12 +11,13 @@ on:
     inputs:
       run-ids:
         description: >
-          Comma-delimited list of IDs of model runs to delete (no spaces). Note
+          Run IDs: Space-delimited list of IDs of model runs to delete. Note
           that the workflow assumes these IDs correspond to model runs for the
-          current upcoming assessment cycle, and if that's not the case the
-          deletion script will raise an error.
+          current assessment cycle, and if that's not the case the deletion
+          script will raise an error.
         required: true
         type: string
+        default: 2024-01-01-foo-bar 2024-01-02-bar-baz
 
 jobs:
   delete-model-runs:
@@ -52,7 +53,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Delete model runs
-        run: Rscript ./R/delete_current_year_model_runs.R "$RUN_IDS"
+        run: Rscript ./R/delete_current_year_model_runs.R "${RUN_IDS// /,}"
         shell: bash
         env:
           RUN_IDS: ${{ inputs.run-ids }}

--- a/.github/workflows/delete-model-runs.yaml
+++ b/.github/workflows/delete-model-runs.yaml
@@ -46,4 +46,4 @@ jobs:
         run: Rscript ./R/delete_current_year_model_runs.R "$RUN_IDS"
         shell: bash
         env:
-          RUN_IDS: 2024-11-14-foo-bar
+          RUN_IDS: 2024-11-14-foo-bar 2024-11-15-baz

--- a/.github/workflows/delete-model-runs.yaml
+++ b/.github/workflows/delete-model-runs.yaml
@@ -7,16 +7,7 @@
 name: delete-model-runs
 
 on:
-  workflow_dispatch:
-    inputs:
-      run-ids:
-        description: >
-          Comma-delimited list of IDs of model runs to delete. Note that the
-          workflow assumes these IDs correspond to model runs for the current
-          upcoming assessment cycle, and if that's not the case the deletion
-          script will raise an error.
-        required: true
-        type: string
+  pull_request:
 
 jobs:
   delete-model-runs:
@@ -41,7 +32,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           # TODO: Create a new role and add it to repo secrets
-          role-to-assume: ${{ secrets.AWS_IAM_ROLE_MODEL_DELETION_ARN }}
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
           aws-region: us-east-1
 
       - name: Delete model runs
@@ -51,4 +42,4 @@ jobs:
           done
         shell: bash
         env:
-          RUN_IDS: ${{ inputs.run-ids }}
+          RUN_IDS: 1,2,3,4,5

--- a/.github/workflows/delete-model-runs.yaml
+++ b/.github/workflows/delete-model-runs.yaml
@@ -46,4 +46,4 @@ jobs:
         run: Rscript ./R/delete_current_year_model_runs.R "$RUN_IDS"
         shell: bash
         env:
-          RUN_IDS: 2023-11-14-frosty-jacob,2024-11-15-baz
+          RUN_IDS: 2023-11-14-frosty-jacob,2023-11-13-stupefied-liz

--- a/.github/workflows/delete-model-runs.yaml
+++ b/.github/workflows/delete-model-runs.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Delete model runs
         run: |
-          for run_id in ${RUN_IDS//,/}; do
+          for run_id in ${RUN_IDS//,/ }; do
             Rscript ./R/delete_current_year_model_runs.R "$run_id"
           done
         shell: bash

--- a/.github/workflows/delete-model-runs.yaml
+++ b/.github/workflows/delete-model-runs.yaml
@@ -7,7 +7,17 @@
 name: delete-model-runs
 
 on:
-  pull_request:
+  workflow_dispatch:
+    inputs:
+      run-ids:
+        description: >
+          Run IDs: Space-delimited list of IDs of model runs to delete. Note
+          that the workflow assumes these IDs correspond to model runs for the
+          current assessment cycle, and if that's not the case the deletion
+          script will raise an error.
+        required: true
+        type: string
+        default: 2024-01-01-foo-bar 2024-01-02-bar-baz
 
 jobs:
   delete-model-runs:
@@ -46,4 +56,4 @@ jobs:
         run: Rscript ./R/delete_current_year_model_runs.R "${RUN_IDS// /,}"
         shell: bash
         env:
-          RUN_IDS: 2024-01-01-foo-bar 2024-01-02-bar-baz
+          RUN_IDS: ${{ inputs.run-ids }}

--- a/.github/workflows/delete-model-runs.yaml
+++ b/.github/workflows/delete-model-runs.yaml
@@ -46,4 +46,4 @@ jobs:
         run: Rscript ./R/delete_current_year_model_runs.R "$RUN_IDS"
         shell: bash
         env:
-          RUN_IDS: 2024-11-14-foo-bar 2024-11-15-baz
+          RUN_IDS: 2024-11-14-foo-bar,2024-11-15-baz

--- a/R/delete_current_year_model_runs.R
+++ b/R/delete_current_year_model_runs.R
@@ -37,11 +37,12 @@ year <- if (current_month < "03") {
 # intended to be called from a dispatched GitHub workflow, it's easier to parse
 # one comma-delimited string than split a space-separated string passed as a
 # workflow input
-run_ids <- commandArgs(trailingOnly = TRUE) %>%
+raw_run_ids <- commandArgs(trailingOnly = TRUE)
+run_ids <- raw_run_ids %>%
   strsplit(split = ",", fixed = TRUE) %>%
   unlist()
 
-"Confirming artifacts exist for run IDs in year {year}: {run_ids}" %>%
+"Confirming artifacts exist for run IDs in year {year}: {raw_run_ids}" %>%
   glue::glue() %>%
   print()
 
@@ -65,6 +66,9 @@ run_id_is_valid <- function(run_id, year) {
 #      before deleting any objects so that this script is nondestructive
 #      in the case of a malformed ID
 valid_run_ids <- run_ids %>% sapply(run_id_is_valid, year = year)
+"Valid run IDs: {paste(valid_run_ids, collapse = ', ')}" %>%
+  glue::glue() %>%
+  print()
 
 if (!all(valid_run_ids)) {
   invalid_run_ids <- run_ids[which(valid_run_ids == FALSE)] %>%

--- a/R/delete_current_year_model_runs.R
+++ b/R/delete_current_year_model_runs.R
@@ -66,9 +66,6 @@ run_id_is_valid <- function(run_id, year) {
 #      before deleting any objects so that this script is nondestructive
 #      in the case of a malformed ID
 valid_run_ids <- run_ids %>% sapply(run_id_is_valid, year = year)
-"Valid run IDs: {paste(valid_run_ids, collapse = ', ')}" %>%
-  glue::glue() %>%
-  print()
 
 if (!all(valid_run_ids)) {
   invalid_run_ids <- run_ids[which(valid_run_ids == FALSE)] %>%

--- a/R/delete_current_year_model_runs.R
+++ b/R/delete_current_year_model_runs.R
@@ -1,22 +1,40 @@
 # Script to delete a list of model runs by ID from AWS.
 #
-# Assumes that model runs are restricted to the current assessment cycle, where
-# each assessment cycle starts in April.
+# Accepts an arbitrary number of arguments, each of which should be the run ID
+# of a model run whose artifacts should be deleted.
 #
-# Raises an error if no objects matching the given ID were deleted.
+# Assumes that model runs are restricted to the current assessment cycle, where
+# each assessment cycle starts in April. Raises an error if no objects matching
+# a given ID for the current year could be located in S3. This error will get
+# raised before any deletion occurs, so if one or more IDs are invalid then
+# no objects will be deleted.
+#
+# Example usage:
+#
+#   delete_current_year_model_runs.R 123 456 789
 
 library(glue)
 library(here)
 library(magrittr)
 source(here("R", "helpers.R"))
 
-# Slightly altered version of model_delete_run from helpers.R that raises an
-# error if no objects were deleted
-delete_run <- function(run_id, year) {
-  deleted_objs <- model_delete_run(run_id, year)
-  if (length(deleted_objs) == 0) {
-    error_msg <- "No objects match the run ID '{run_id}' for year {year}"
-    error_msg %>%
+# Function to check whether S3 artifacts exist for a given model run.
+# Defining this as a separate check from the deletion operation is helpful for
+# two reasons:
+#
+#   1. The aws.s3::delete_object API does not raise an error if an object does
+#      not exist, so a delete operation alone won't alert us for an incorrect
+#      ID
+#   2. Even if aws.s3::delete_object could raise an error for missing objects,
+#      we want to alert the caller that one or more of the IDs were incorrect
+#      before deleting any objects so that this script is nondestructive
+#      in the case of a malformed ID
+raise_if_run_id_is_invalid <- function(run_id, year) {
+  artifacts_exist <- model_get_s3_artifacts_for_run(run_id, year) %>%
+    sapply(aws.s3::object_exists)
+
+  if (!any(artifacts_exist)) {
+    "Model run {run_id} for year {year} is missing all S3 artifacts" %>%
       glue::glue() %>%
       stop()
   }
@@ -38,9 +56,17 @@ year <- if (current_month < "03") {
 
 run_ids <- commandArgs(trailingOnly = TRUE)
 
-log_msg <- "Deleting run IDs for year {year}: {run_ids}"
-log_msg %>%
+"Confirming artifacts exist for run IDs in year {year}: {run_ids}" %>%
   glue::glue() %>%
   print()
 
-run_ids %>% sapply(delete_run, year = year)
+# For a future improvement, it would probably be more user friendly to catch
+# the missing artifact errors raised by raise_if_run_id_is_invalid and compile
+# a list of all invalid run IDs before raising
+run_ids %>% sapply(raise_if_run_id_is_invalid, year = year)
+
+"Deleting S3 artifacts run IDs in year {year}: {run_ids}" %>%
+  glue::glue() %>%
+  print()
+
+run_ids %>% sapply(model_delete_run, year = year)

--- a/R/delete_current_year_model_runs.R
+++ b/R/delete_current_year_model_runs.R
@@ -2,10 +2,25 @@
 #
 # Assumes that model runs are restricted to the current assessment cycle, where
 # each assessment cycle starts in April.
+#
+# Raises an error if no objects matching the given ID were deleted.
 
+library(glue)
 library(here)
 library(magrittr)
 source(here("R", "helpers.R"))
+
+# Slightly altered version of model_delete_run from helpers.R that raises an
+# error if no objects were deleted
+delete_run <- function(run_id, year) {
+  deleted_objs <- model_delete_run(run_id, year)
+  if (length(deleted_objs) == 0) {
+    error_msg <- "No objects match the run ID '{run_id}' for year {year}"
+    error_msg %>%
+      glue::glue() %>%
+      stop()
+  }
+}
 
 current_date <- as.POSIXct(Sys.Date())
 current_month <- current_date %>% format("%m")
@@ -23,6 +38,9 @@ year <- if (current_month < "03") {
 
 run_ids <- commandArgs(trailingOnly = TRUE)
 
-sprintf("Deleting run IDs for year %s: %s", year, run_ids)
+log_msg <- "Deleting run IDs for year {year}: {run_ids}"
+log_msg %>%
+  glue::glue() %>%
+  print()
 
-run_ids %>% sapply(model_delete_run, year = year)
+run_ids %>% sapply(delete_run, year = year)

--- a/R/delete_current_year_model_runs.R
+++ b/R/delete_current_year_model_runs.R
@@ -1,0 +1,24 @@
+# Script to delete a list of model runs by ID from AWS.
+#
+# Assumes that model runs are restricted to the current upcoming
+# assessment cycle year.
+
+library(here)
+library(magrittr)
+source(here("R", "helpers.R"))
+
+current_date <- as.POSIXct(Sys.Date())
+current_month <- current_date %>% format("%m")
+current_year <- current_date %>% format("%Y")
+
+# The following heuristic determines the current upcoming assessment cycle year:
+#
+#   * From March to December (post assessment), `year` = next year
+#   * From January to March (during assessment), `year` = current year
+year <- if(current_month < "03") current_year else as.character(as.numeric(current_year) + 1)
+
+run_ids <- commandArgs(trailingOnly = TRUE)
+
+sprintf("Deleting run IDs for year %s: %s", year, run_ids)
+
+run_ids %>% sapply(model_delete_run, year = year)

--- a/R/delete_current_year_model_runs.R
+++ b/R/delete_current_year_model_runs.R
@@ -4,7 +4,7 @@
 # whose artifacts should be deleted.
 #
 # Assumes that model runs are restricted to the current assessment cycle, where
-# each assessment cycle starts in April. Raises an error if no objects matching
+# each assessment cycle starts in May. Raises an error if no objects matching
 # a given ID for the current year could be located in S3. This error will get
 # raised before any deletion occurs, so if one or more IDs are invalid then
 # no objects will be deleted.
@@ -24,9 +24,9 @@ current_year <- current_date %>% format("%Y")
 
 # The following heuristic determines the current upcoming assessment cycle year:
 #
-#   * From April to December (post assessment), `year` = next year
-#   * From January to March (during assessment), `year` = current year
-year <- if (current_month < "03") {
+#   * From May to December (post assessment), `year` = next year
+#   * From January to April (during assessment), `year` = current year
+year <- if (current_month < "05") {
   current_year
 } else {
   as.character(as.numeric(current_year) + 1)
@@ -35,8 +35,8 @@ year <- if (current_month < "03") {
 # Convert the comma-delimited input to a vector of run IDs. Accepting one or
 # more positional arguments would be a cleaner UX, but since this script is
 # intended to be called from a dispatched GitHub workflow, it's easier to parse
-# one comma-delimited string than split a space-separated string passed as a
-# workflow input
+# one comma-delimited string than convert a space-separated string passed as a
+# workflow input to an array of function arguments
 raw_run_ids <- commandArgs(trailingOnly = TRUE)
 run_ids <- raw_run_ids %>%
   strsplit(split = ",", fixed = TRUE) %>%

--- a/R/delete_current_year_model_runs.R
+++ b/R/delete_current_year_model_runs.R
@@ -1,7 +1,7 @@
 # Script to delete a list of model runs by ID from AWS.
 #
-# Assumes that model runs are restricted to the current upcoming
-# assessment cycle year.
+# Assumes that model runs are restricted to the current assessment cycle, where
+# each assessment cycle starts in April.
 
 library(here)
 library(magrittr)
@@ -13,7 +13,7 @@ current_year <- current_date %>% format("%Y")
 
 # The following heuristic determines the current upcoming assessment cycle year:
 #
-#   * From March to December (post assessment), `year` = next year
+#   * From April to December (post assessment), `year` = next year
 #   * From January to March (during assessment), `year` = current year
 year <- if (current_month < "03") current_year else as.character(as.numeric(current_year) + 1)
 
@@ -21,4 +21,4 @@ run_ids <- commandArgs(trailingOnly = TRUE)
 
 sprintf("Deleting run IDs for year %s: %s", year, run_ids)
 
-# run_ids %>% sapply(model_delete_run, year = year)
+run_ids %>% sapply(model_delete_run, year = year)

--- a/R/delete_current_year_model_runs.R
+++ b/R/delete_current_year_model_runs.R
@@ -21,4 +21,4 @@ run_ids <- commandArgs(trailingOnly = TRUE)
 
 sprintf("Deleting run IDs for year %s: %s", year, run_ids)
 
-run_ids %>% sapply(model_delete_run, year = year)
+# run_ids %>% sapply(model_delete_run, year = year)

--- a/R/delete_current_year_model_runs.R
+++ b/R/delete_current_year_model_runs.R
@@ -15,7 +15,7 @@ current_year <- current_date %>% format("%Y")
 #
 #   * From March to December (post assessment), `year` = next year
 #   * From January to March (during assessment), `year` = current year
-year <- if(current_month < "03") current_year else as.character(as.numeric(current_year) + 1)
+year <- if (current_month < "03") current_year else as.character(as.numeric(current_year) + 1)
 
 run_ids <- commandArgs(trailingOnly = TRUE)
 

--- a/R/delete_current_year_model_runs.R
+++ b/R/delete_current_year_model_runs.R
@@ -15,7 +15,11 @@ current_year <- current_date %>% format("%Y")
 #
 #   * From April to December (post assessment), `year` = next year
 #   * From January to March (during assessment), `year` = current year
-year <- if (current_month < "03") current_year else as.character(as.numeric(current_year) + 1)
+year <- if (current_month < "03") {
+  current_year
+} else {
+  as.character(as.numeric(current_year) + 1)
+}
 
 run_ids <- commandArgs(trailingOnly = TRUE)
 

--- a/R/delete_current_year_model_runs.R
+++ b/R/delete_current_year_model_runs.R
@@ -18,28 +18,6 @@ library(here)
 library(magrittr)
 source(here("R", "helpers.R"))
 
-# Function to check whether S3 artifacts exist for a given model run.
-# Defining this as a separate check from the deletion operation is helpful for
-# two reasons:
-#
-#   1. The aws.s3::delete_object API does not raise an error if an object does
-#      not exist, so a delete operation alone won't alert us for an incorrect
-#      ID
-#   2. Even if aws.s3::delete_object could raise an error for missing objects,
-#      we want to alert the caller that one or more of the IDs were incorrect
-#      before deleting any objects so that this script is nondestructive
-#      in the case of a malformed ID
-raise_if_run_id_is_invalid <- function(run_id, year) {
-  artifacts_exist <- model_get_s3_artifacts_for_run(run_id, year) %>%
-    sapply(aws.s3::object_exists)
-
-  if (!any(artifacts_exist)) {
-    "Model run {run_id} for year {year} is missing all S3 artifacts" %>%
-      glue::glue() %>%
-      stop()
-  }
-}
-
 current_date <- as.POSIXct(Sys.Date())
 current_month <- current_date %>% format("%m")
 current_year <- current_date %>% format("%Y")
@@ -60,10 +38,35 @@ run_ids <- commandArgs(trailingOnly = TRUE)
   glue::glue() %>%
   print()
 
-# For a future improvement, it would probably be more user friendly to catch
-# the missing artifact errors raised by raise_if_run_id_is_invalid and compile
-# a list of all invalid run IDs before raising
-run_ids %>% sapply(raise_if_run_id_is_invalid, year = year)
+# We consider a run ID to be valid if it has any matching data in S3 for
+# the current year
+run_id_is_valid <- function(run_id, year) {
+  return(
+    model_get_s3_artifacts_for_run(run_id, year) %>%
+      sapply(aws.s3::object_exists) %>%
+      any()
+  )
+}
+
+# We check for validity separate from the deletion operation for two reasons:
+#
+#   1. The aws.s3::delete_object API does not raise an error if an object does
+#      not exist, so a delete operation alone won't alert us for an incorrect
+#      ID
+#   2. Even if aws.s3::delete_object could raise an error for missing objects,
+#      we want to alert the caller that one or more of the IDs were incorrect
+#      before deleting any objects so that this script is nondestructive
+#      in the case of a malformed ID
+valid_run_ids <- run_ids %>% sapply(run_id_is_valid, year = year)
+
+if (!all(valid_run_ids)) {
+  invalid_run_ids <- run_ids[which(valid_run_ids == FALSE)] %>%
+    paste(collapse = ", ")
+
+  "Some run IDs are missing all S3 artifacts for {year}: {invalid_run_ids}" %>%
+    glue::glue() %>%
+    stop()
+}
 
 "Deleting S3 artifacts run IDs in year {year}: {run_ids}" %>%
   glue::glue() %>%

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -28,18 +28,16 @@ model_file_dict <- function(run_id = NULL, year = NULL) {
   return(dict)
 }
 
-
-# Used to delete erroneous, incomplete, or otherwise unwanted runs
-# Use with caution! Deleted models are retained for a period of time before
-# being permanently deleted
-model_delete_run <- function(run_id, year) {
+# Get a vector of S3 paths to the artifacts for a given model run
+model_get_s3_artifacts_for_run <- function(run_id, year) {
   # Get paths of all run objects based on the file dictionary
   paths <- model_file_dict(run_id, year)
   s3_objs <- grep("s3://", unlist(paths), value = TRUE)
   bucket <- strsplit(s3_objs[1], "/")[[1]][3]
 
   # First get anything partitioned only by year
-  s3_objs_limited <- grep(".parquet$|.zip$|.rds$", s3_objs, value = TRUE)
+  s3_objs_limited <- grep(".parquet$|.zip$|.rds$", s3_objs, value = TRUE) %>%
+    unname()
 
   # Next get the prefix of anything partitioned by year and run_id
   s3_objs_dir_path <- file.path(
@@ -53,22 +51,21 @@ model_delete_run <- function(run_id, year) {
   )
   s3_objs_dir_path <- gsub(paste0("s3://", bucket, "/"), "", s3_objs_dir_path)
   s3_objs_dir_path <- gsub("//", "/", s3_objs_dir_path)
-  s3_objs_w_run_id <- unlist(purrr::map(
-    s3_objs_dir_path,
-    ~ aws.s3::get_bucket_df(bucket, .x)$Key
-  ))
+  s3_objs_w_run_id <- s3_objs_dir_path %>%
+    purrr::map(~ aws.s3::get_bucket_df(bucket, .x)$Key) %>%
+    unlist() %>%
+    purrr::map_chr(~ glue::glue("s3://{bucket}/{.x}"))
 
-  # Delete current version of objects
-  del_objs_limited <- purrr::walk(s3_objs_limited, aws.s3::delete_object)
-  del_objs_w_run_id <- purrr::walk(
-    s3_objs_w_run_id,
-    aws.s3::delete_object,
-    bucket = bucket
-  )
-
-  return(c(del_objs_limited, del_objs_w_run_id))
+  return(c(s3_objs_limited, s3_objs_w_run_id))
 }
 
+# Used to delete erroneous, incomplete, or otherwise unwanted runs
+# Use with caution! Deleted models are retained for a period of time before
+# being permanently deleted
+model_delete_run <- function(run_id, year) {
+  model_get_s3_artifacts_for_run(run_id, year) %>%
+    purrr::walk(aws.s3::delete_object)
+}
 
 # Used to fetch a run's output from S3 and populate it locally. Useful for
 # running reports and performing local troubleshooting

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -59,8 +59,14 @@ model_delete_run <- function(run_id, year) {
   ))
 
   # Delete current version of objects
-  purrr::walk(s3_objs_limited, aws.s3::delete_object)
-  purrr::walk(s3_objs_w_run_id, aws.s3::delete_object, bucket = bucket)
+  del_objs_limited <- purrr::walk(s3_objs_limited, aws.s3::delete_object)
+  del_objs_w_run_id <- purrr::walk(
+    s3_objs_w_run_id,
+    aws.s3::delete_object,
+    bucket = bucket
+  )
+
+  return(c(del_objs_limited, del_objs_w_run_id))
 }
 
 


### PR DESCRIPTION
This PR adds a new workflow, `delete-model-runs` that can be dispatched with a comma-delimited string of model run IDs to delete models that have been run for the current assessment cycle.

Models in previous assessment cycles are protected from deletion in two ways:

* The script will derive the current assessment cycle year, and will only look for model runs with the given ID in that year; if the model run is not present in the current year, the script will raise an error before attempting to delete any runs
* The IAM role that the script is run with only has permissions to delete models for the current assessment year, and AWS will raise an error if the workflow somehow attempts to delete models from a previous year

**One high level question about the condo model**: I've been assuming that we need to port these changes over to the condo model before we can count #56 as complete, but taking a look at the `file_dict.csv`s for both repos, it seems like there aren't actually any differences in the output paths for the model artifacts; the models are simply distinguished by their autogenerated run IDs. **Do we need to port this code over to the condo model, or is it good enough to use the workflow in this repo to delete condo model runs?** I think the tradeoff is that it would be more confusing from an operational perspective to need to delete condo model runs from the context of a `model-res-avm` workflow, but at the same time it would make long-term maintenance easier since we don't need to maintain two copies of the `delete-model-runs` workflow (I'm assuming that it's not worth extracting this logic out into a shared external workflow [as we did for `build-and-run-model`](https://github.com/ccao-data/model-res-avm/pull/59) because I don't imagine that this logic will be particularly useful outside the context of the res and condo model repos).

Connects https://github.com/ccao-data/model-res-avm/issues/56. 