### PR TITLE
Refactor `assess` and `evaluate` stages for speed

### DIFF
--- a/02-assess-old.R
+++ b/02-assess-old.R
@@ -1,0 +1,559 @@
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# 1. Setup ---------------------------------------------------------------------
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+# NOTE: See DESCRIPTION for library dependencies and R/setup.R for
+# variables used in each pipeline stage
+
+# Start the stage timer and clear logs from prior stage
+tictoc::tic.clearlog()
+tictoc::tic("Assess")
+
+# Load libraries, helpers, and recipes from files
+purrr::walk(list.files("R/", "\\.R$", full.names = TRUE), source)
+
+# Columns to use for ratio study comparison (by prefix)
+rsf_prefix <- gsub("_tot", "", params$ratio_study$far_column)
+rsn_prefix <- gsub("_tot", "", params$ratio_study$near_column)
+
+# Load the training data to use as a source of sales. These will be attached to
+# PIN-level output (for comparison) and used as the basis for a sales ratio
+# analysis on the assessment data
+sales_data_2 <- read_parquet(paths$input$training$local) %>%
+  filter(!sv_is_outlier)
+
+# Load land rates from file
+land_site_rate_2 <- read_parquet(
+  paths$input$land_site_rate$local,
+  c("meta_pin", "land_rate_per_pin")
+)
+land_nbhd_rate_2 <- read_parquet(
+  paths$input$land_nbhd_rate$local
+)
+
+
+
+
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# 2. Predict Values ------------------------------------------------------------
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+message("Predicting off-market values with trained model")
+
+# Load the final lightgbm model object and recipe from file
+lgbm_final_full_fit <- lightsnip::lgbm_load(paths$output$workflow_fit$local)
+lgbm_final_full_recipe <- readRDS(paths$output$workflow_recipe$local)
+
+# Load the data for assessment. This is the universe of CARDs (not
+# PINs) that needs values. Use the trained lightgbm model to estimate a single
+# fair-market value for each card
+assessment_card_data_pred_2 <- read_parquet(paths$input$assessment$local) %>%
+  as_tibble() %>%
+  mutate(
+    pred_card_initial_fmv = predict(
+      lgbm_final_full_fit,
+      new_data = bake(
+        lgbm_final_full_recipe,
+        new_data = .,
+        all_predictors()
+      )
+    )$.pred
+  )
+
+
+
+
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# 3. Post-Modeling Adjustments -------------------------------------------------
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+message("Performing post-modeling adjustments")
+
+## 3.1. Multicards -------------------------------------------------------------
+message("Fixing multicard PINs")
+
+# Cards represent buildings/improvements. A PIN can have multiple cards, and
+# the total taxable value of the PIN is (usually) the sum of all cards
+assessment_card_data_mc_2 <- assessment_card_data_pred_2 %>%
+  select(
+    meta_year, meta_pin, meta_nbhd_code, meta_class, meta_card_num,
+    char_bldg_sf, char_land_sf,
+    meta_tieback_key_pin, meta_tieback_proration_rate,
+    meta_1yr_pri_board_tot, pred_card_initial_fmv
+  ) %>%
+  # For prorated PINs with multiple cards, take the average of the card
+  # (building) across PINs. This is because the same prorated building spread
+  # across multiple PINs sometimes receives different values from the model
+  group_by(meta_tieback_key_pin, meta_card_num) %>%
+  mutate(
+    pred_card_intermediate_fmv = ifelse(
+      is.na(meta_tieback_key_pin),
+      pred_card_initial_fmv,
+      mean(pred_card_initial_fmv)
+    )
+  ) %>%
+  # Aggregate multi-cards to the PIN-level by summing the predictions
+  # of all cards. We use a heuristic here to limit the PIN-level total
+  # value, this is to prevent super-high-value back-buildings/ADUs from
+  # blowing up the PIN-level AV
+  group_by(meta_pin) %>%
+  mutate(
+    pred_pin_card_sum = ifelse(
+      sum(pred_card_intermediate_fmv) * meta_tieback_proration_rate <=
+        params$pv$multicard_yoy_cap *
+          dplyr::first(meta_1yr_pri_board_tot * 10) |
+        is.na(meta_1yr_pri_board_tot) |
+        n() != 2,
+      sum(pred_card_intermediate_fmv),
+      max(pred_card_intermediate_fmv)
+    )
+  ) %>%
+  ungroup()
+
+
+## 3.2. Townhomes --------------------------------------------------------------
+message("Averaging townhome complex predictions")
+
+# For class 210 and 295s, we want all units in the same complex to
+# have the same value (assuming they are nearly identical)
+
+# Load townhome/rowhome complex IDs
+complex_id_data_2 <- read_parquet(paths$input$complex_id$local) %>%
+  select(meta_pin, meta_complex_id)
+
+# Join complex IDs to the predictions, then for each complex, set the
+# prediction to the average prediction of the complex
+assessment_card_data_cid_2 <- assessment_card_data_mc_2 %>%
+  left_join(complex_id_data_2, by = "meta_pin") %>%
+  group_by(meta_complex_id, meta_tieback_proration_rate) %>%
+  mutate(
+    pred_pin_final_fmv = ifelse(
+      is.na(meta_complex_id),
+      pred_pin_card_sum,
+      mean(pred_pin_card_sum)
+    )
+  ) %>%
+  ungroup()
+
+
+## 3.3. Round ------------------------------------------------------------------
+message("Rounding predictions")
+
+# Round PIN-level predictions using the breaks and amounts specified in params
+assessment_card_data_round_2 <- assessment_card_data_cid_2 %>%
+  mutate(
+    pred_pin_final_fmv_round_no_prorate = ccao::val_round_fmv(
+      pred_pin_final_fmv,
+      breaks = params$pv$round_break,
+      round_to = params$pv$round_to_nearest,
+      type = params$pv$round_type
+    )
+  )
+
+
+
+
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# 4. Value Land ----------------------------------------------------------------
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+message("Valuing land")
+
+# Land values are provided by Valuations and are capped at a percentage of the
+# total FMV for the PIN. For 210 and 295s (townhomes), there's sometimes a pre-
+# calculated land total value, for all other classes, there's a $/sqft rate
+assessment_pin_data_w_land_2 <- assessment_card_data_round_2 %>%
+  # Keep only the necessary unique PIN-level values, since land is valued by
+  # PIN rather than card
+  group_by(meta_year, meta_pin) %>%
+  distinct(
+    meta_nbhd_code, meta_complex_id,
+    meta_tieback_key_pin, meta_tieback_proration_rate,
+    char_land_sf, pred_pin_final_fmv, pred_pin_final_fmv_round_no_prorate
+  ) %>%
+  ungroup() %>%
+  left_join(land_site_rate_2, by = "meta_pin") %>%
+  left_join(land_nbhd_rate_2, by = c("meta_nbhd_code" = "meta_nbhd")) %>%
+  mutate(
+    pred_pin_final_fmv_land = ceiling(case_when(
+      # nolint start
+      # Use the fixed late value first (unless it exceeds the land % cap)
+      !is.na(land_rate_per_pin) &
+        (land_rate_per_pin > pred_pin_final_fmv_round_no_prorate *
+          params$pv$land_pct_of_total_cap) ~
+        pred_pin_final_fmv_round_no_prorate * params$pv$land_pct_of_total_cap,
+      !is.na(land_rate_per_pin) ~ land_rate_per_pin,
+      # nolint end
+      # Otherwise, use the land $/sqft rate (again checking against the cap)
+      char_land_sf * land_rate_per_sqft >= pred_pin_final_fmv_round_no_prorate *
+        params$pv$land_pct_of_total_cap ~
+        pred_pin_final_fmv_round_no_prorate * params$pv$land_pct_of_total_cap,
+      TRUE ~ char_land_sf * land_rate_per_sqft
+    )),
+    # Keep the uncapped value for display in desk review
+    pred_pin_uncapped_fmv_land = ceiling(case_when(
+      !is.na(land_rate_per_pin) ~ land_rate_per_pin,
+      TRUE ~ char_land_sf * land_rate_per_sqft
+    ))
+  )
+
+
+
+
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# 5. Prorate and Reapportion ---------------------------------------------------
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+message("Prorating buildings")
+
+# Prorating is the process of dividing a building's value among multiple PINs.
+# See the steps outlined below for the process to determine a prorated value:
+assessment_pin_data_prorated_2 <- assessment_pin_data_w_land_2 %>%
+  group_by(meta_tieback_key_pin) %>%
+  mutate(
+    tieback_total_land_fmv = ifelse(
+      is.na(meta_tieback_key_pin),
+      pred_pin_final_fmv_land,
+      sum(pred_pin_final_fmv_land)
+    )
+  ) %>%
+  ungroup() %>%
+  mutate(
+    # 1. Subtract the TOTAL value of the land of all linked PINs. This leaves
+    # only the value of the building that spans the PINs
+    pred_pin_final_fmv_bldg_no_prorate =
+      pred_pin_final_fmv_round_no_prorate - tieback_total_land_fmv,
+    # 2. Multiply the building by the proration rate of each PIN/card. This is
+    # the proportion of the building's value held by each PIN
+    pred_pin_final_fmv_bldg =
+      pred_pin_final_fmv_bldg_no_prorate * meta_tieback_proration_rate,
+    temp_bldg_frac_prop =
+      pred_pin_final_fmv_bldg - as.integer(pred_pin_final_fmv_bldg)
+  ) %>%
+  # 3. Assign the fractional portion of a building (cents) to whichever portion
+  # is largest i.e. [1.59, 1.41] becomes [2, 1]
+  group_by(meta_tieback_key_pin) %>%
+  arrange(desc(temp_bldg_frac_prop)) %>%
+  mutate(
+    temp_add_to_final = as.numeric(
+      n() > 1 & row_number() == 1 & temp_bldg_frac_prop > 0.1e-7
+    ),
+    temp_add_diff = temp_add_to_final * round(
+      sum(pred_pin_final_fmv_bldg, na.rm = TRUE) -
+        sum(as.integer(pred_pin_final_fmv_bldg), na.rm = TRUE)
+    ),
+    pred_pin_final_fmv_bldg = as.integer(pred_pin_final_fmv_bldg) +
+      temp_add_diff
+  ) %>%
+  ungroup() %>%
+  select(-starts_with("temp_")) %>%
+  mutate(
+    # 4. To get the total value of the individual PINs, add the individual land
+    # value of the PINs back to the prorated building value
+    pred_pin_final_fmv_round =
+      pred_pin_final_fmv_bldg + pred_pin_final_fmv_land
+  ) %>%
+  arrange(meta_pin)
+
+# Merge the final PIN-level data back to the main tibble of predictions
+assessment_card_data_merged_2 <- assessment_pin_data_prorated_2 %>%
+  select(
+    meta_year, meta_pin, meta_complex_id,
+    pred_pin_final_fmv, pred_pin_final_fmv_round_no_prorate,
+    land_rate_per_pin, land_rate_per_sqft, pred_pin_uncapped_fmv_land,
+    pred_pin_final_fmv_land, pred_pin_final_fmv_bldg_no_prorate,
+    pred_pin_final_fmv_bldg, pred_pin_final_fmv_round
+  ) %>%
+  left_join(
+    assessment_card_data_pred_2,
+    by = c("meta_year", "meta_pin"),
+    multiple = "all"
+  ) %>%
+  mutate(
+    township_code = meta_township_code,
+    meta_year = as.character(meta_year)
+  ) %>%
+  # Apportion the final prorated PIN-level value back out to the card-level
+  # using the square footage of each improvement
+  group_by(meta_year, meta_pin) %>%
+  mutate(
+    meta_card_pct_total_fmv = char_bldg_sf / sum(char_bldg_sf),
+    # In cases where bldg sqft is missing (rare), fill evenly across cards
+    meta_card_pct_total_fmv = ifelse(
+      is.na(meta_card_pct_total_fmv),
+      1 / n(),
+      meta_card_pct_total_fmv
+    ),
+    pred_card_final_fmv = pred_pin_final_fmv_bldg * meta_card_pct_total_fmv,
+    temp_card_frac_prop = pred_card_final_fmv - as.integer(pred_card_final_fmv)
+  ) %>%
+  # More fractional rounding to deal with card values being split into cents
+  group_by(meta_year, meta_pin) %>%
+  arrange(desc(temp_card_frac_prop)) %>%
+  mutate(
+    temp_add_to_final = as.numeric(
+      n() > 1 & row_number() == 1 & temp_card_frac_prop > 0.1e-7
+    ),
+    temp_add_diff = temp_add_to_final * (
+      sum(pred_card_final_fmv, na.rm = TRUE) -
+        sum(as.integer(pred_card_final_fmv), na.rm = TRUE)
+    ),
+    pred_card_final_fmv = round(as.integer(pred_card_final_fmv) + temp_add_diff)
+  ) %>%
+  ungroup() %>%
+  select(-starts_with("temp_")) %>%
+  arrange(meta_pin)
+
+# The test PINs below can be used to ensure that the order of operations
+# for the adjustments above results in a sensible outcome:
+# 17321110470000 05174150240000 05213220250000 08121220400000 06334030310000
+# 16071280240000 17223100350000 30201160060000 16071280240000 25293010470000
+
+
+
+
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# 6. Card-Level Data -----------------------------------------------------------
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+message("Saving card-level data")
+
+# Keep only card-level variables of interest, including: ID variables (run_id,
+# pin, card), characteristics, and predictions
+assessment_card_data_merged_2 %>%
+  select(
+    meta_year, meta_pin, meta_class, meta_card_num, meta_card_pct_total_fmv,
+    meta_complex_id, pred_card_initial_fmv, pred_card_final_fmv,
+    all_of(params$model$predictor$all), township_code
+  ) %>%
+  mutate(meta_complex_id = as.numeric(meta_complex_id)) %>%
+  ccao::vars_recode(
+    starts_with("char_"),
+    type = "long",
+    as_factor = FALSE
+  ) %>%
+  write_parquet(paths$output$assessment_card$local)
+
+
+
+
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# 7. PIN-Level Data ------------------------------------------------------------
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+# Generate PIN-level stats for each run. These are used for desktop review,
+# looking at YoY changes, comparing to sales, etc.
+
+## 7.1. Load Sales/Land --------------------------------------------------------
+message("Attaching recent sales to PIN-level data")
+
+# Load the MOST RECENT sale per PIN from the year prior to the assessment year.
+# These are the sales that will be used for ratio studies in the evaluate stage.
+# We want our assessed value to be as close as possible to this sale
+sales_data_ratio_study_2 <- sales_data_2 %>%
+  filter(meta_year == params$assessment$data_year) %>%
+  group_by(meta_pin) %>%
+  filter(meta_sale_date == max(meta_sale_date)) %>%
+  distinct(
+    meta_pin, meta_year,
+    sale_ratio_study_price = meta_sale_price,
+    sale_ratio_study_date = meta_sale_date,
+    sale_ratio_study_document_num = meta_sale_document_num
+  ) %>%
+  ungroup()
+
+# Keep the two most recent sales for each PIN from any year. These are just for
+# review, not for ratio studies
+sales_data_two_most_recent_2 <- sales_data_2 %>%
+  group_by(meta_pin) %>%
+  distinct(
+    meta_pin, meta_year,
+    meta_sale_price, meta_sale_date, meta_sale_document_num
+  ) %>%
+  slice_max(meta_sale_date, n = 2) %>%
+  mutate(mr = paste0("sale_recent_", row_number())) %>%
+  tidyr::pivot_wider(
+    id_cols = meta_pin,
+    names_from = mr,
+    values_from = c(meta_sale_date, meta_sale_price, meta_sale_document_num),
+    names_glue = "{mr}_{gsub('meta_sale_', '', .value)}"
+  ) %>%
+  select(meta_pin, contains("1"), contains("2")) %>%
+  ungroup()
+
+
+## 7.2. Collapse to PIN Level --------------------------------------------------
+message("Collapsing card-level data to PIN level")
+
+# Collapse card-level data to the PIN level, keeping the largest building on
+# each PIN but summing the total square footage of all buildings
+assessment_pin_data_base_2 <- assessment_card_data_merged_2 %>%
+  group_by(meta_year, meta_pin) %>%
+  arrange(desc(char_bldg_sf)) %>%
+  mutate(
+    # Keep the sum of the initial card level values
+    pred_pin_initial_fmv = sum(pred_card_initial_fmv),
+    char_total_bldg_sf = sum(char_bldg_sf, na.rm = TRUE)
+  ) %>%
+  filter(row_number() == 1) %>%
+  # Rename prior year comparison columns to near/far to maintain consistent
+  # column names in Athena
+  rename_with(
+    .fn = ~ gsub(paste0(rsn_prefix, "_"), "prior_near_", .x),
+    .cols = starts_with(rsn_prefix)
+  ) %>%
+  rename_with(
+    .fn = ~ gsub(paste0(rsf_prefix, "_"), "prior_far_", .x),
+    .cols = starts_with(rsf_prefix)
+  ) %>%
+  ungroup() %>%
+  select(
+    # Keep ID and meta variables
+    meta_year, meta_pin, meta_triad_code, meta_township_code, meta_nbhd_code,
+    meta_tax_code, meta_class, meta_tieback_key_pin,
+    meta_tieback_proration_rate, meta_cdu, meta_pin_num_cards,
+    meta_pin_num_landlines, meta_complex_id,
+
+    # Keep certain vital characteristics for the largest card on the PIN
+    char_yrblt, char_land_sf, char_ext_wall, char_type_resd, char_total_bldg_sf,
+
+    # Keep locations, prior year values, and indicators
+    loc_longitude, loc_latitude,
+    starts_with(c(
+      "loc_property_", "loc_cook_", "loc_chicago_", "loc_ward_",
+      "loc_census", "loc_school_", "prior_", "ind_"
+    )),
+
+    # Keep HIE flag
+    hie_num_expired,
+
+    # Keep PIN-level predicted values and land rates
+    land_rate_per_pin, land_rate_per_sqft,
+    pred_pin_initial_fmv,
+    pred_pin_final_fmv, pred_pin_final_fmv_round_no_prorate,
+    pred_pin_uncapped_fmv_land, pred_pin_final_fmv_land,
+    pred_pin_final_fmv_bldg_no_prorate, pred_pin_final_fmv_bldg,
+    pred_pin_final_fmv_round, township_code
+  ) %>%
+  # Make a flag for any vital missing characteristics
+  bind_cols(
+    assessment_card_data_merged_2 %>%
+      group_by(meta_year, meta_pin) %>%
+      arrange(desc(char_bldg_sf)) %>%
+      ungroup() %>%
+      select(
+        meta_year, meta_pin,
+        char_yrblt, char_bldg_sf, char_land_sf, char_beds,
+        char_fbath, char_apts
+      ) %>%
+      mutate(ind_char_missing_critical_value = rowSums(is.na(.))) %>%
+      group_by(meta_year, meta_pin) %>%
+      summarize(
+        ind_char_missing_critical_value =
+          sum(ind_char_missing_critical_value) > 0
+      ) %>%
+      ungroup() %>%
+      select(ind_char_missing_critical_value)
+  )
+
+
+## 7.3. Attach Sales -----------------------------------------------------------
+message("Attaching and comparing sale values")
+
+# Attach sales data to the PIN-level data
+assessment_pin_data_sale_2 <- assessment_pin_data_base_2 %>%
+  left_join(sales_data_two_most_recent_2, by = "meta_pin") %>%
+  left_join(sales_data_ratio_study_2, by = c("meta_year", "meta_pin")) %>%
+  # Calculate effective land rates (rate with 50% cap) + the % of the PIN value
+  # dedicated to the building
+  mutate(
+    pred_pin_land_rate_effective = pred_pin_final_fmv_land / char_land_sf,
+    pred_pin_bldg_rate_effective = pred_pin_final_fmv_bldg / char_total_bldg_sf,
+    pred_pin_land_pct_total = pred_pin_final_fmv_land / pred_pin_final_fmv_round
+  ) %>%
+  # Convert prior values to FMV from AV, then calculate year-over-year
+  # percent and nominal changes
+  mutate(
+    across(starts_with("prior_"), ~ .x * 10),
+    prior_far_yoy_change_nom = pred_pin_final_fmv_round - prior_far_tot,
+    prior_far_yoy_change_pct = prior_far_yoy_change_nom / prior_far_tot,
+    prior_near_yoy_change_nom = pred_pin_final_fmv_round - prior_near_tot,
+    prior_near_yoy_change_pct = prior_near_yoy_change_nom / prior_near_tot
+  )
+
+
+## 7.4. Add Flags --------------------------------------------------------------
+message("Adding Desk Review flags")
+
+# Flags are used to identify PINs for potential desktop review
+assessment_pin_data_final_2 <- assessment_pin_data_sale_2 %>%
+  # Rename existing indicators to flags
+  rename_with(~ gsub("ind_", "flag_", .x), starts_with("ind_")) %>%
+  # Add flag for potential proration issues (rates don't sum to 1)
+  group_by(meta_tieback_key_pin) %>%
+  mutate(flag_proration_sum_not_1 = ifelse(
+    !is.na(meta_tieback_key_pin),
+    sum(meta_tieback_proration_rate) != 1,
+    FALSE
+  )) %>%
+  ungroup() %>%
+  # Flag for capped land value
+  mutate(
+    flag_land_value_capped = pred_pin_final_fmv_round *
+      params$pv$land_pct_of_total_cap == pred_pin_final_fmv_land
+  ) %>%
+  # Flags for changes in values
+  mutate(
+    flag_prior_near_to_pred_unchanged =
+      prior_near_tot >= pred_pin_final_fmv_round - 100 &
+        prior_near_tot <= pred_pin_final_fmv_round + 100, # nolint
+    flag_pred_initial_to_final_changed = ccao::val_round_fmv(
+      pred_pin_initial_fmv,
+      breaks = params$pv$round_break,
+      round_to = params$pv$round_to_nearest,
+      type = params$pv$round_type
+    ) != pred_pin_final_fmv_round,
+    flag_prior_near_yoy_inc_gt_50_pct = prior_near_yoy_change_pct > 0.5,
+    flag_prior_near_yoy_dec_gt_5_pct = prior_near_yoy_change_pct < -0.05,
+  ) %>%
+  # Flag high-value properties from prior years
+  group_by(meta_township_code) %>%
+  mutate(flag_prior_near_fmv_top_decile = ntile(prior_near_tot, 10) == 10) %>%
+  ungroup() %>%
+  # Flags for HIEs / 288s (placeholder until 288 data is integrated)
+  rename(flag_hie_num_expired = hie_num_expired) %>%
+  mutate(
+    flag_hie_num_expired = tidyr::replace_na(flag_hie_num_expired, 0),
+    meta_pin_num_landlines = tidyr::replace_na(meta_pin_num_landlines, 1),
+    flag_pin_is_multiland = tidyr::replace_na(flag_pin_is_multiland, FALSE)
+  )
+
+
+## 7.5. Clean/Reorder/Save -----------------------------------------------------
+message("Saving final PIN-level data")
+
+# Recode characteristics from numeric encodings to human-readable strings
+assessment_pin_data_final_2 %>%
+  ccao::vars_recode(
+    cols = starts_with("char_"),
+    type = "short",
+    as_factor = FALSE
+  ) %>%
+  mutate(meta_complex_id = as.numeric(meta_complex_id)) %>%
+  # Reorder columns into groups by prefix
+  select(
+    starts_with(c("meta_", "loc_")), char_yrblt, char_total_bldg_sf,
+    char_ext_wall, char_type_resd, char_land_sf,
+    starts_with(c("land", "prior_far_", "prior_near_")),
+    pred_pin_initial_fmv, pred_pin_final_fmv,
+    pred_pin_final_fmv_round_no_prorate,
+    pred_pin_final_fmv_bldg_no_prorate, pred_pin_final_fmv_land,
+    pred_pin_final_fmv_bldg, pred_pin_final_fmv_round,
+    pred_pin_bldg_rate_effective, pred_pin_land_rate_effective,
+    pred_pin_land_pct_total, starts_with(c("sale_", "flag_")), township_code
+  ) %>%
+  as_tibble() %>%
+  write_parquet(paths$output$assessment_pin$local)
+
+# End the stage timer and write the time elapsed to a temporary file
+tictoc::toc(log = TRUE)
+bind_rows(tictoc::tic.log(format = FALSE)) %>%
+  arrow::write_parquet(gsub("//*", "/", file.path(
+    paths$intermediate$timing$local,
+    "model_timing_assess.parquet"
+  )))

--- a/02-assess-old.R
+++ b/02-assess-old.R
@@ -512,6 +512,7 @@ assessment_pin_data_final_2 <- assessment_pin_data_sale_2 %>%
     flag_prior_near_yoy_dec_gt_5_pct = prior_near_yoy_change_pct < -0.05,
   ) %>%
   # Flag high-value properties from prior years
+  arrange(meta_year, meta_pin) %>%
   group_by(meta_township_code) %>%
   mutate(flag_prior_near_fmv_top_decile = ntile(prior_near_tot, 10) == 10) %>%
   ungroup() %>%

--- a/03-evaluate-old.R
+++ b/03-evaluate-old.R
@@ -1,0 +1,440 @@
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# 1. Setup ---------------------------------------------------------------------
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+# NOTE: See DESCRIPTION for library dependencies and R/setup.R for
+# variables used in each pipeline stage
+
+# Start the stage timer and clear logs from prior stage
+tictoc::tic.clearlog()
+tictoc::tic("Evaluate")
+
+# Load libraries, helpers, and recipes from files
+purrr::walk(list.files("R/", "\\.R$", full.names = TRUE), source)
+
+# Enable parallel backend for generating stats more quickly
+plan(multisession, workers = num_threads)
+
+# Renaming dictionary for input columns. We want the actual value of the column
+# to become geography_id and the NAME of the column to become geography_name
+col_rename_dict <- c(
+  "triad_code" = "meta_triad_code",
+  "class" = "meta_class",
+  "geography_id" = "meta_township_code",
+  "geography_id" = "meta_township_name",
+  "geography_id" = "meta_nbhd_code",
+  "geography_id" = "loc_cook_municipality_name",
+  "geography_id" = "loc_ward_num",
+  "geography_id" = "loc_census_puma_geoid",
+  "geography_id" = "loc_census_tract_geoid",
+  "geography_id" = "loc_school_elementary_district_geoid",
+  "geography_id" = "loc_school_secondary_district_geoid",
+  "geography_id" = "loc_school_unified_district_geoid"
+)
+
+# Get the triad of the run to use for filtering
+run_triad <- tools::toTitleCase(params$assessment$triad)
+run_triad_code <- ccao::town_dict %>%
+  filter(triad_name == run_triad) %>%
+  distinct(triad_code) %>%
+  pull(triad_code)
+
+
+
+
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# 2. Load Data -----------------------------------------------------------------
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+message("Loading evaluation data")
+
+# Load the test results from the end of the train stage. This will be the most
+# recent 10% of sales and already includes predictions. This data will NOT
+# include multicard sales, so the unit of observation is PINs (1 PIN per row)
+test_data_card <- read_parquet(paths$output$test_card$local)
+
+# Load the assessment results from the previous stage. This will include every
+# residential PIN that needs a value. It WILL include multicard properties
+# aggregated to the PIN-level. Only runs for full runs due to compute cost
+if (run_type == "full") {
+  assessment_data_pin <- read_parquet(paths$output$assessment_pin$local) %>%
+    filter(meta_triad_code == run_triad_code) %>%
+    select(
+      meta_pin, meta_class, meta_triad_code, meta_township_code, meta_nbhd_code,
+      loc_cook_municipality_name, loc_ward_num, loc_census_puma_geoid,
+      loc_census_tract_geoid, loc_school_elementary_district_geoid,
+      loc_school_secondary_district_geoid, loc_school_unified_district_geoid,
+      char_total_bldg_sf, prior_far_tot, prior_near_tot,
+      pred_pin_final_fmv_round, sale_ratio_study_price
+    )
+}
+
+
+
+
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# 3. Define Stats Functions ----------------------------------------------------
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+# Function to take either test set results or assessment results and generate
+# aggregate performance statistics for different levels of geography
+gen_agg_stats <- function(data, truth, estimate, bldg_sqft,
+                          rsn_col, rsf_col, triad, geography, class, col_dict) {
+  # List of summary stat/performance functions applied within summarize() below
+  # Each function is listed on the right while the name of the function is on
+  # the left
+  rs_fns_list <- list(
+    cod_no_sop = ~ ifelse(sum(!is.na(.y)) > 1, cod(.x / .y, na.rm = TRUE), NA),
+    prd_no_sop = ~ ifelse(sum(!is.na(.y)) > 1, prd(.x, .y, na.rm = TRUE), NA),
+    prb_no_sop = ~ ifelse(sum(!is.na(.y)) > 1, prb(.x, .y, na.rm = TRUE), NA),
+    cod = ~ ifelse(
+      sum(!is.na(.y)) > 33,
+      list(ccao_cod(.x / .y, na.rm = TRUE)),
+      NA
+    ),
+    prd = ~ ifelse(
+      sum(!is.na(.y)) > 33,
+      list(ccao_prd(.x, .y, na.rm = TRUE)),
+      NA
+    ),
+    prb = ~ ifelse(
+      sum(!is.na(.y)) > 33,
+      list(ccao_prb(.x, .y, na.rm = TRUE)),
+      NA
+    )
+  )
+  ys_fns_list <- list(
+    rmse        = rmse_vec,
+    r_squared   = rsq_vec,
+    mae         = mae_vec,
+    mpe         = mpe_vec,
+    mape        = mape_vec
+  )
+  sum_fns_list <- list(
+    min         = ~ min(.x, na.rm = TRUE),
+    q25         = ~ quantile(.x, na.rm = TRUE, probs = 0.25),
+    median      = ~ median(.x, na.rm = TRUE),
+    q75         = ~ quantile(.x, na.rm = TRUE, probs = 0.75),
+    max         = ~ max(.x, na.rm = TRUE)
+  )
+  sum_sqft_fns_list <- list(
+    min         = ~ min(.x / .y, na.rm = TRUE),
+    q25         = ~ quantile(.x / .y, na.rm = TRUE, probs = 0.25),
+    median      = ~ median(.x / .y, na.rm = TRUE),
+    q75         = ~ quantile(.x / .y, na.rm = TRUE, probs = 0.75),
+    max         = ~ max(.x / .y, na.rm = TRUE)
+  )
+  yoy_fns_list <- list(
+    min         = ~ min((.x - .y) / .y, na.rm = TRUE),
+    q25         = ~ quantile((.x - .y) / .y, na.rm = TRUE, probs = 0.25),
+    median      = ~ median((.x - .y) / .y, na.rm = TRUE),
+    q75         = ~ quantile((.x - .y) / .y, na.rm = TRUE, probs = 0.75),
+    max         = ~ max((.x - .y) / .y, na.rm = TRUE)
+  )
+
+  # Generate aggregate performance stats by geography
+  df_stat <- data %>%
+    # Aggregate to get counts by geography without class
+    group_by({{ triad }}, {{ geography }}) %>%
+    mutate(
+      num_pin_no_class = n(),
+      num_sale_no_class = sum(!is.na({{ truth }}))
+    ) %>%
+    # Aggregate including class
+    group_by({{ triad }}, {{ geography }}, {{ class }}) %>%
+    summarize(
+
+      # Basic summary stats, counts, proportions, etc
+      num_pin = n(),
+      num_sale = sum(!is.na({{ truth }})),
+      pct_of_total_pin_by_class = num_pin / first(num_pin_no_class),
+      pct_of_total_sale_by_class = num_sale / first(num_sale_no_class),
+      pct_of_pin_sold = num_sale / num_pin,
+      prior_far_total_av = sum({{ rsf_col }} / 10, na.rm = TRUE),
+      prior_near_total_av = sum({{ rsn_col }} / 10, na.rm = TRUE),
+      estimate_total_av = sum({{ estimate }} / 10, na.rm = TRUE),
+
+      # Assessment-specific statistics
+      across(
+        .fns = rs_fns_list, {{ estimate }}, {{ truth }},
+        .names = "{.fn}"
+      ),
+      median_ratio = median({{ estimate }} / {{ truth }}, na.rm = TRUE),
+
+      # Yardstick (ML-specific) performance stats
+      across(.fns = ys_fns_list, {{ truth }}, {{ estimate }}, .names = "{.fn}"),
+
+      # Summary stats of sale price and sale price per sqft
+      across(.fns = sum_fns_list, {{ truth }}, .names = "sale_fmv_{.fn}"),
+      across(
+        .fns = sum_sqft_fns_list, {{ truth }}, {{ bldg_sqft }},
+        .names = "sale_fmv_per_sqft_{.fn}"
+      ),
+
+      # Summary stats of prior values and value per sqft. Need to multiply
+      # by 10 first since PIN history is in AV, not FMV
+      prior_far_num_missing = sum(is.na({{ rsf_col }})),
+      across(
+        .fns = sum_fns_list, {{ rsf_col }},
+        .names = "prior_far_fmv_{.fn}"
+      ),
+      across(
+        .fns = sum_sqft_fns_list, {{ rsf_col }}, {{ bldg_sqft }},
+        .names = "prior_far_fmv_per_sqft_{.fn}"
+      ),
+      across(
+        .fns = yoy_fns_list, {{ estimate }}, {{ rsf_col }},
+        .names = "prior_far_yoy_pct_chg_{.fn}"
+      ),
+      prior_near_num_missing = sum(is.na({{ rsn_col }})),
+      across(
+        .fns = sum_fns_list, {{ rsn_col }},
+        .names = "prior_near_fmv_{.fn}"
+      ),
+      across(
+        .fns = sum_sqft_fns_list, {{ rsn_col }}, {{ bldg_sqft }},
+        .names = "prior_near_fmv_per_sqft_{.fn}"
+      ),
+      across(
+        .fns = yoy_fns_list, {{ estimate }}, {{ rsn_col }},
+        .names = "prior_near_yoy_pct_chg_{.fn}"
+      ),
+
+      # Summary stats of estimate value and estimate per sqft
+      estimate_num_missing = sum(is.na({{ estimate }})),
+      across(
+        .fns = sum_fns_list, {{ estimate }},
+        .names = "estimate_fmv_{.fn}"
+      ),
+      across(
+        .fns = sum_sqft_fns_list, {{ estimate }}, {{ bldg_sqft }},
+        .names = "estimate_fmv_per_sqft_{.fn}"
+      ),
+      .groups = "drop"
+    ) %>%
+    ungroup() %>%
+    # COD, PRD, and PRB all output to a list. We can unnest each list to get
+    # additional info for each stat (95% CI, sample count, etc)
+    tidyr::unnest_wider(cod) %>%
+    tidyr::unnest_wider(COD_CI, names_sep = "_") %>%
+    tidyr::unnest_wider(prd) %>%
+    tidyr::unnest_wider(PRD_CI, names_sep = "_") %>%
+    tidyr::unnest_wider(prb) %>%
+    tidyr::unnest_wider(PRB_CI, names_sep = "_") %>%
+    # Rename columns resulting from unnesting
+    rename_with(~ gsub("%", "", gsub("\\.", "_", tolower(.x))))
+
+  # Clean up the stats output (rename cols, relocate cols, etc.)
+  df_stat %>%
+    mutate(
+      by_class = !is.null({{ class }}),
+      geography_type = ifelse(
+        !is.null({{ geography }}),
+        ccao::vars_rename(
+          rlang::as_string(rlang::ensym(geography)),
+          names_from = "model",
+          names_to = "athena"
+        ),
+        "triad_code"
+      )
+    ) %>%
+    rename(any_of(col_dict)) %>%
+    relocate(
+      any_of(c("geography_type", "geography_id", "by_class", "class")),
+      .after = "triad_code"
+    ) %>%
+    mutate(across(
+      -(contains("_max") & contains("yoy")) & where(is.numeric),
+      ~ replace(.x, !is.finite(.x), NA)
+    ))
+}
+
+
+# Same as the gen_agg_stats function, but with different statistics and broken
+# out by quantile
+gen_agg_stats_quantile <- function(data, truth, estimate,
+                                   rsn_col, rsf_col, triad, geography,
+                                   class, col_dict, num_quantile) {
+  # Calculate the median ratio by quantile of sale price, plus the upper and
+  # lower bounds of each quantile
+  df_quantile <- data %>%
+    group_by({{ triad }}, {{ geography }}, {{ class }}) %>%
+    mutate(quantile = ntile({{ truth }}, n = num_quantile)) %>%
+    group_by({{ triad }}, {{ geography }}, {{ class }}, quantile) %>%
+    summarize(
+      num_sale = sum(!is.na({{ truth }})),
+      median_ratio = median(({{ estimate }} / {{ truth }}), na.rm = TRUE),
+      lower_bound = min({{ truth }}, na.rm = TRUE),
+      upper_bound = max({{ truth }}, na.rm = TRUE),
+      prior_near_yoy_pct_chg_median = median(
+        ({{ estimate }} - {{ rsn_col }}) / {{ rsn_col }},
+        na.rm = TRUE
+      ),
+      prior_far_yoy_pct_chg_median = median(
+        ({{ estimate }} - {{ rsf_col }}) / {{ rsf_col }},
+        na.rm = TRUE
+      ),
+      .groups = "drop"
+    ) %>%
+    ungroup()
+
+  # Clean up the quantile output
+  df_quantile %>%
+    mutate(
+      num_quantile = num_quantile,
+      by_class = !is.null({{ class }}),
+      geography_type = ifelse(
+        !is.null({{ geography }}),
+        ccao::vars_rename(
+          rlang::as_string(rlang::ensym(geography)),
+          names_from = "model",
+          names_to = "athena"
+        ),
+        "triad_code"
+      )
+    ) %>%
+    filter(!is.na(quantile)) %>%
+    rename(any_of(col_dict)) %>%
+    relocate(
+      any_of(c(
+        "geography_type", "geography_id",
+        "by_class", "class", "num_quantile"
+      )),
+      .after = "triad_code"
+    ) %>%
+    mutate(across(
+      -(contains("_max") & contains("yoy")) & where(is.numeric),
+      ~ replace(.x, !is.finite(.x), NA)
+    ))
+}
+
+
+
+
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# 4. Generate Stats ------------------------------------------------------------
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+# Use fancy tidyeval to create a list of all the geography levels with a
+# class or no class option for each level
+geographies_quosures <- rlang::quos(
+  meta_township_code,
+  meta_nbhd_code, loc_cook_municipality_name,
+  loc_ward_num, loc_census_puma_geoid, loc_census_tract_geoid,
+  loc_school_elementary_district_geoid, loc_school_secondary_district_geoid,
+  loc_school_unified_district_geoid,
+  NULL
+)
+geographies_list <- purrr::cross2(
+  geographies_quosures,
+  rlang::quos(meta_class, NULL)
+)
+
+# Same as above, but add quantile breakouts to the grid expansion
+geographies_list_quantile <- purrr::cross3(
+  geographies_quosures,
+  rlang::quos(meta_class, NULL),
+  params$ratio_study$num_quantile
+)
+
+
+## 4.1. Test Set ---------------------------------------------------------------
+
+# Use parallel map to calculate aggregate stats for every geography level and
+# class combination for the test set
+message("Calculating test set aggregate statistics")
+future_map_dfr(
+  geographies_list,
+  ~ gen_agg_stats(
+    data = test_data_card,
+    truth = meta_sale_price,
+    estimate = pred_card_initial_fmv,
+    bldg_sqft = char_bldg_sf,
+    rsn_col = prior_near_tot,
+    rsf_col = prior_far_tot,
+    triad = meta_triad_code,
+    geography = !!.x[[1]],
+    class = !!.x[[2]],
+    col_dict = col_rename_dict
+  ),
+  .options = furrr_options(seed = TRUE, stdout = FALSE),
+  .progress = FALSE
+) %>%
+  write_parquet(paths$output$performance_test$local)
+
+# Same as above, but calculate stats per quantile of sale price
+message("Calculating test set quantile statistics")
+future_map_dfr(
+  geographies_list_quantile,
+  ~ gen_agg_stats_quantile(
+    data = test_data_card,
+    truth = meta_sale_price,
+    estimate = pred_card_initial_fmv,
+    rsn_col = prior_near_tot,
+    rsf_col = prior_far_tot,
+    triad = meta_triad_code,
+    geography = !!.x[[1]],
+    class = !!.x[[2]],
+    col_dict = col_rename_dict,
+    num_quantile = .x[[3]]
+  ),
+  .options = furrr_options(seed = TRUE, stdout = FALSE),
+  .progress = FALSE
+) %>%
+  write_parquet(paths$output$performance_quantile_test$local)
+
+
+## 4.2. Assessment Set ---------------------------------------------------------
+
+# Only value the assessment set for full runs
+if (run_type == "full") {
+  # Do the same thing for the assessment set. This will have accurate property
+  # counts and proportions, since it also includes unsold properties
+  message("Calculating assessment set aggregate statistics")
+  future_map_dfr(
+    geographies_list,
+    ~ gen_agg_stats(
+      data = assessment_data_pin,
+      truth = sale_ratio_study_price,
+      estimate = pred_pin_final_fmv_round,
+      bldg_sqft = char_total_bldg_sf,
+      rsn_col = prior_near_tot,
+      rsf_col = prior_far_tot,
+      triad = meta_triad_code,
+      geography = !!.x[[1]],
+      class = !!.x[[2]],
+      col_dict = col_rename_dict
+    ),
+    .options = furrr_options(seed = TRUE, stdout = FALSE),
+    .progress = FALSE
+  ) %>%
+    write_parquet(paths$output$performance_assessment$local)
+
+  # Same as above, but calculate stats per quantile of sale price
+  message("Calculating assessment set quantile statistics")
+  future_map_dfr(
+    geographies_list_quantile,
+    ~ gen_agg_stats_quantile(
+      data = assessment_data_pin,
+      truth = sale_ratio_study_price,
+      estimate = pred_pin_final_fmv_round,
+      rsn_col = prior_near_tot,
+      rsf_col = prior_far_tot,
+      triad = meta_triad_code,
+      geography = !!.x[[1]],
+      class = !!.x[[2]],
+      col_dict = col_rename_dict,
+      num_quantile = .x[[3]]
+    ),
+    .options = furrr_options(seed = TRUE, stdout = FALSE),
+    .progress = FALSE
+  ) %>%
+    write_parquet(paths$output$performance_quantile_assessment$local)
+}
+
+# End the stage timer and write the time elapsed to a temporary file
+tictoc::toc(log = TRUE)
+bind_rows(tictoc::tic.log(format = FALSE)) %>%
+  arrow::write_parquet(gsub("//*", "/", file.path(
+    paths$intermediate$timing$local,
+    "model_timing_evaluate.parquet"
+  )))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,7 @@ Depends:
     butcher,
     ccao,
     conflicted,
+    data.table,
     dplyr,
     furrr,
     git2r,

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -214,3 +214,13 @@ var_encode <- function(data,
     })
   )
 }
+
+
+# Move selected columns after the selected column. Taken from:
+# https://github.com/Rdatatable/data.table/issues/4358
+dt_move_after <- function(x, neworder = NULL, after = NULL) {
+  neworder <- data.table:::colnamesInt(x, neworder, check_dups = FALSE)
+  neworder <- c(setdiff(seq_len(data.table:::colnamesInt(x, after)), neworder), neworder) # nolint
+  neworder <- c(neworder, setdiff(seq_along(x), neworder))
+  setcolorder(x, neworder)
+}

--- a/R/setup.R
+++ b/R/setup.R
@@ -22,6 +22,7 @@ suppressPackageStartupMessages({
 conflicts_prefer(
   data.table::`:=`,
   dplyr::filter,
+  dplyr::first,
   dplyr::lag,
   dplyr::pull,
   dplyr::slice,

--- a/R/setup.R
+++ b/R/setup.R
@@ -20,6 +20,7 @@ suppressPackageStartupMessages({
 # Resolve package namespace conflicts, preferring the library::function pair
 # shown over other functions with the same name from different libraries
 conflicts_prefer(
+  data.table::`:=`,
   dplyr::filter,
   dplyr::lag,
   dplyr::pull,

--- a/R/setup.R
+++ b/R/setup.R
@@ -28,6 +28,7 @@ conflicts_prefer(
   dplyr::slice,
   lubridate::duration,
   purrr::flatten,
+  purrr::is_empty,
   purrr::set_names,
   purrr::splice,
   purrr::when,

--- a/R/setup.R
+++ b/R/setup.R
@@ -50,6 +50,7 @@ params <- read_yaml("params.yaml")
 # Lightgbm docs recommend using only real cores, not logical
 # https://lightgbm.readthedocs.io/en/latest/Parameters.html#num_threads
 num_threads <- parallel::detectCores(logical = FALSE)
+data.table::setDTthreads(num_threads)
 
 # Set the overall model seed
 set.seed(params$model$seed)

--- a/compare.R
+++ b/compare.R
@@ -1,0 +1,59 @@
+all.equal(
+  data.frame(assessment_card_data_pred),
+  data.frame(assessment_card_data_pred_2)
+)
+
+all.equal(
+  data.frame(assessment_card_data_mc),
+  data.frame(assessment_card_data_mc_2)
+)
+
+all.equal(
+  data.frame(assessment_card_data_cid),
+  data.frame(assessment_card_data_cid_2)
+)
+
+all.equal(
+  data.frame(assessment_card_data_round),
+  data.frame(assessment_card_data_round_2)
+)
+
+all.equal(
+  data.frame(assessment_pin_data_w_land),
+  data.frame(assessment_pin_data_w_land_2)
+)
+
+all.equal(
+  data.frame(assessment_pin_data_prorated),
+  data.frame(assessment_pin_data_prorated_2)
+)
+
+all.equal(
+  data.frame(assessment_card_data_merged),
+  data.frame(assessment_card_data_merged_2)
+)
+
+all.equal(
+  data.frame(sales_data_ratio_study),
+  data.frame(sales_data_ratio_study_2)
+)
+
+all.equal(
+  data.frame(sales_data_two_most_recent),
+  data.frame(sales_data_two_most_recent_2)
+)
+
+all.equal(
+  data.frame(assessment_pin_data_base),
+  data.frame(assessment_pin_data_base_2 %>% arrange(meta_year, meta_pin))
+)
+
+all.equal(
+  data.frame(assessment_pin_data_sale),
+  data.frame(assessment_pin_data_sale_2 %>% arrange(meta_year, meta_pin))
+)
+
+all.equal(
+  data.frame(assessment_pin_data_final),
+  data.frame(assessment_pin_data_final_2 %>% arrange(meta_year, meta_pin))
+)

--- a/params.yaml
+++ b/params.yaml
@@ -15,10 +15,10 @@ run_note: |
   Test run for updated 2024 model pipeline. Uses 2022 data to assess 2023
   since full 2023 data isn't available yet
 
-# Determines what stages and outputs are produced. See misc/file_dict.csv for
-# details. Note, DVC does not support "conditional" stages, so changing this to
-# anything other than "full" will require you to run each stage manually. See
-# README for details
+# Determines what stages and outputs are produced. Options are
+# "limited" or "full". See misc/file_dict.csv for details. Note, DVC does not
+# support "conditional" stages, so changing this to anything other than "full"
+# will require you to run each stage manually.
 run_type: "full"
 
 toggle:
@@ -361,8 +361,22 @@ ratio_study:
   near_stage: "certified"
   near_column: "meta_certified_tot"
 
+  # Geographies for which to calculate performance statistics in the evaluate
+  # stage. Each geography is also broken out by class
+  geographies: [
+    "meta_township_code",
+    "meta_nbhd_code",
+    "loc_cook_municipality_name",
+    "loc_ward_num",
+    "loc_census_puma_geoid",
+    "loc_census_tract_geoid",
+    "loc_school_elementary_district_geoid",
+    "loc_school_secondary_district_geoid",
+    "loc_school_unified_district_geoid"
+  ]
+
   # Quantile breakouts to use in the evaluate stage. For example, 3 will split
-  # each geography in evaluate into terciles
+  # each geography listed above into terciles
   num_quantile: [3, 5, 10]
 
 

--- a/pipeline/02-assess.R
+++ b/pipeline/02-assess.R
@@ -72,110 +72,40 @@ message("Fixing multicard PINs")
 
 # Cards represent buildings/improvements. A PIN can have multiple cards, and
 # the total taxable value of the PIN is (usually) the sum of all cards
-tictoc::tic()
-assessment_card_data_mc <- lazy_dt(assessment_card_data_pred) %>%
-  select(
-    meta_year, meta_pin, meta_nbhd_code, meta_class, meta_card_num,
-    char_bldg_sf, char_land_sf,
-    meta_tieback_key_pin, meta_tieback_proration_rate,
-    meta_1yr_pri_board_tot, pred_card_initial_fmv
-  ) %>%
-  # For prorated PINs with multiple cards, take the average of the card
-  # (building) across PINs. This is because the same prorated building spread
-  # across multiple PINs sometimes receives different values from the model
-  group_by(meta_tieback_key_pin, meta_card_num) %>%
-  mutate(
-    mean_pred_card_initial_fmv = mean(pred_card_initial_fmv),
-    missing_val = is.na(meta_tieback_key_pin)
-  ) %>%
-  ungroup() %>%
-  mutate(
-    pred_card_intermediate_fmv = ifelse(
-      missing_val,
-      pred_card_initial_fmv,
-      mean_pred_card_initial_fmv
-    )
-  ) %>%
-  select(-c(mean_pred_card_initial_fmv, missing_val)) %>%
-  # Aggregate multi-cards to the PIN-level by summing the predictions
-  # of all cards. We use a heuristic here to limit the PIN-level total
-  # value, this is to prevent super-high-value back-buildings/ADUs from
-  # blowing up the PIN-level AV
-  group_by(meta_pin) %>%
-  mutate(
-    sum_pred_card_intermediate_fmv = sum(pred_card_intermediate_fmv),
-    max_pred_card_intermediate_fmv = max(pred_card_intermediate_fmv),
-    first_meta_1yr_pri_board_tot_fmv = first(meta_1yr_pri_board_tot * 10),
-    missing_val = is.na(meta_1yr_pri_board_tot),
-    pin_count = n()
-  ) %>%
-  ungroup() %>%
-  mutate(
-    pred_pin_card_sum = ifelse(
-      sum_pred_card_intermediate_fmv * meta_tieback_proration_rate <=
-        params$pv$multicard_yoy_cap * first_meta_1yr_pri_board_tot_fmv |
-        missing_val |
-        pin_count != 2,
-      sum_pred_card_intermediate_fmv,
-      max_pred_card_intermediate_fmv
-    )
-  ) %>%
-  select(-c(
-    sum_pred_card_intermediate_fmv, max_pred_card_intermediate_fmv,
-    first_meta_1yr_pri_board_tot_fmv, missing_val, pin_count
-  )) %>%
-  collect()
-tictoc::toc()
-
-library(data.table)
-setDT(assessment_card_data_pred)
-
-tictoc::tic()
-assessment_card_data_mc <- assessment_card_data_pred[, .(
+assessment_card_data_mc <- setDT(assessment_card_data_pred)[, .(
   meta_year, meta_pin, meta_nbhd_code, meta_class, meta_card_num,
   char_bldg_sf, char_land_sf,
   meta_tieback_key_pin, meta_tieback_proration_rate,
   meta_1yr_pri_board_tot, pred_card_initial_fmv
 )][
-  ,
-  mean_pred_card_initial_fmv := mean(pred_card_initial_fmv),
+  # For prorated PINs with multiple cards, take the average of the card
+  # (building) across PINs. This is because the same prorated building spread
+  # across multiple PINs sometimes receives different values from the model
+  !is.na(meta_tieback_key_pin),
+  pred_card_intermediate_fmv := mean(pred_card_initial_fmv),
   by = .(meta_tieback_key_pin, meta_card_num)
 ][
-  ,
-  missing_val := is.na(meta_tieback_key_pin)
+  is.na(meta_tieback_key_pin),
+  pred_card_intermediate_fmv := pred_card_initial_fmv
 ][
-  ,
-  pred_card_intermediate_fmv := fifelse(
-    missing_val,
-    pred_card_initial_fmv,
-    mean_pred_card_initial_fmv
-  )
-][
-  ,
-  `:=`(
-    pred_card_intermediate_fmv = sum(pred_card_intermediate_fmv),
-    max_pred_card_intermediate_fmv = max(pred_card_intermediate_fmv),
-    first_meta_1yr_pri_board_tot_fmv =
-      data.table::first(meta_1yr_pri_board_tot * 10),
-    missing_val = data.table::first(missing_val),
-    pin_count = .N
-  ),
-  by = .(meta_pin)
-][
+  # Aggregate multi-cards to the PIN-level by summing the predictions
+  # of all cards. We use a heuristic here to limit the PIN-level total
+  # value, this is to prevent super-high-value back-buildings/ADUs from
+  # blowing up the PIN-level AV
   ,
   pred_pin_card_sum := fifelse(
-    pred_card_intermediate_fmv * meta_tieback_proration_rate <=
-      params$pv$multicard_yoy_cap * first_meta_1yr_pri_board_tot_fmv |
-      missing_val |
-      pin_count != 2,
-    pred_card_intermediate_fmv,
-    max_pred_card_intermediate_fmv
-  )
+    sum(pred_card_intermediate_fmv) * meta_tieback_proration_rate <=
+      params$pv$multicard_yoy_cap *
+        data.table::first(meta_1yr_pri_board_tot * 10) |
+      is.na(meta_1yr_pri_board_tot) | .N != 2,
+    sum(pred_card_intermediate_fmv),
+    max(pred_card_intermediate_fmv)
+  ),
+  keyby = .(meta_pin)
 ]
-tictoc::toc()
 
 
-conflicts_prefer(data.table::`:=`)
+
 
 ## 3.2. Townhomes --------------------------------------------------------------
 message("Averaging townhome complex predictions")

--- a/pipeline/02-assess.R
+++ b/pipeline/02-assess.R
@@ -5,6 +5,9 @@
 # NOTE: See DESCRIPTION for library dependencies and R/setup.R for
 # variables used in each pipeline stage
 
+# NOTE: This script uses the data.table package for some transformations instead
+# of dplyr for performance reasons (~10x speed up vs dplyr for group operations)
+
 # Start the stage timer and clear logs from prior stage
 tictoc::tic.clearlog()
 tictoc::tic("Assess")
@@ -20,7 +23,8 @@ rsn_prefix <- gsub("_tot", "", params$ratio_study$near_column)
 # PIN-level output (for comparison) and used as the basis for a sales ratio
 # analysis on the assessment data
 sales_data <- read_parquet(paths$input$training$local) %>%
-  filter(!sv_is_outlier)
+  filter(!sv_is_outlier) %>%
+  setDT()
 
 # Load land rates from file
 land_site_rate <- read_parquet(
@@ -57,7 +61,8 @@ assessment_card_data_pred <- read_parquet(paths$input$assessment$local) %>%
         all_predictors()
       )
     )$.pred
-  )
+  ) %>%
+  setDT()
 
 
 
@@ -72,7 +77,7 @@ message("Fixing multicard PINs")
 
 # Cards represent buildings/improvements. A PIN can have multiple cards, and
 # the total taxable value of the PIN is (usually) the sum of all cards
-assessment_card_data_mc <- setDT(assessment_card_data_pred)[, .(
+assessment_card_data_mc <- assessment_card_data_pred[, .(
   meta_year, meta_pin, meta_nbhd_code, meta_class, meta_card_num,
   char_bldg_sf, char_land_sf,
   meta_tieback_key_pin, meta_tieback_proration_rate,
@@ -101,7 +106,7 @@ assessment_card_data_mc <- setDT(assessment_card_data_pred)[, .(
     sum(pred_card_intermediate_fmv),
     max(pred_card_intermediate_fmv)
   ),
-  keyby = .(meta_pin)
+  by = .(meta_pin)
 ]
 
 
@@ -114,39 +119,38 @@ message("Averaging townhome complex predictions")
 # have the same value (assuming they are nearly identical)
 
 # Load townhome/rowhome complex IDs
-complex_id_data <- read_parquet(paths$input$complex_id$local) %>%
-  select(meta_pin, meta_complex_id)
+complex_id_data <- setDT(read_parquet(paths$input$complex_id$local))
+complex_id_data <- complex_id_data[, .(meta_pin, meta_complex_id)]
 
 # Join complex IDs to the predictions, then for each complex, set the
 # prediction to the average prediction of the complex
-assessment_card_data_cid <- assessment_card_data_mc %>%
-  left_join(complex_id_data, by = "meta_pin") %>%
-  group_by(meta_complex_id, meta_tieback_proration_rate) %>%
-  mutate(mean_pred_pin_card_sum = mean(pred_pin_card_sum)) %>%
-  ungroup() %>%
-  mutate(
-    pred_pin_final_fmv = ifelse(
-      is.na(meta_complex_id),
-      pred_pin_card_sum,
-      mean_pred_pin_card_sum
-    )
-  ) %>%
-  select(-mean_pred_pin_card_sum)
+assessment_card_data_cid <- copy(assessment_card_data_mc)[
+  complex_id_data,
+  meta_complex_id := i.meta_complex_id,
+  on = .(meta_pin)
+][
+  is.na(meta_complex_id),
+  pred_pin_final_fmv := pred_pin_card_sum
+][
+  !is.na(meta_complex_id),
+  pred_pin_final_fmv := mean(pred_pin_card_sum),
+  by = .(meta_complex_id, meta_tieback_proration_rate)
+]
 
 
 ## 3.3. Round ------------------------------------------------------------------
 message("Rounding predictions")
 
 # Round PIN-level predictions using the breaks and amounts specified in params
-assessment_card_data_round <- assessment_card_data_cid %>%
-  mutate(
-    pred_pin_final_fmv_round_no_prorate = ccao::val_round_fmv(
-      pred_pin_final_fmv,
-      breaks = params$pv$round_break,
-      round_to = params$pv$round_to_nearest,
-      type = params$pv$round_type
-    )
+assessment_card_data_round <- copy(assessment_card_data_cid)[
+  ,
+  pred_pin_final_fmv_round_no_prorate := ccao::val_round_fmv(
+    pred_pin_final_fmv,
+    breaks = params$pv$round_break,
+    round_to = params$pv$round_to_nearest,
+    type = params$pv$round_type
   )
+]
 
 
 
@@ -159,40 +163,58 @@ message("Valuing land")
 # Land values are provided by Valuations and are capped at a percentage of the
 # total FMV for the PIN. For 210 and 295s (townhomes), there's sometimes a pre-
 # calculated land total value, for all other classes, there's a $/sqft rate
-assessment_pin_data_w_land <- assessment_card_data_round %>%
-  # Keep only the necessary unique PIN-level values, since land is valued by
-  # PIN rather than card
-  group_by(meta_year, meta_pin) %>%
-  distinct(
-    meta_nbhd_code, meta_complex_id,
+assessment_pin_data_w_land <- unique(
+  assessment_card_data_round,
+  by = c("meta_year", "meta_pin")
+)[
+  ,
+  .(
+    meta_year, meta_pin, meta_nbhd_code, meta_complex_id,
     meta_tieback_key_pin, meta_tieback_proration_rate,
     char_land_sf, pred_pin_final_fmv, pred_pin_final_fmv_round_no_prorate
-  ) %>%
-  ungroup() %>%
-  left_join(land_site_rate, by = "meta_pin") %>%
-  left_join(land_nbhd_rate, by = c("meta_nbhd_code" = "meta_nbhd")) %>%
-  mutate(
-    pred_pin_final_fmv_land = ceiling(case_when(
-      # nolint start
-      # Use the fixed late value first (unless it exceeds the land % cap)
-      !is.na(land_rate_per_pin) &
-        (land_rate_per_pin > pred_pin_final_fmv_round_no_prorate *
-          params$pv$land_pct_of_total_cap) ~
-        pred_pin_final_fmv_round_no_prorate * params$pv$land_pct_of_total_cap,
-      !is.na(land_rate_per_pin) ~ land_rate_per_pin,
-      # nolint end
-      # Otherwise, use the land $/sqft rate (again checking against the cap)
-      char_land_sf * land_rate_per_sqft >= pred_pin_final_fmv_round_no_prorate *
-        params$pv$land_pct_of_total_cap ~
-        pred_pin_final_fmv_round_no_prorate * params$pv$land_pct_of_total_cap,
-      TRUE ~ char_land_sf * land_rate_per_sqft
-    )),
-    # Keep the uncapped value for display in desk review
-    pred_pin_uncapped_fmv_land = ceiling(case_when(
-      !is.na(land_rate_per_pin) ~ land_rate_per_pin,
-      TRUE ~ char_land_sf * land_rate_per_sqft
-    ))
   )
+][
+  land_site_rate,
+  land_rate_per_pin := i.land_rate_per_pin,
+  on = .(meta_pin)
+][
+  land_nbhd_rate,
+  land_rate_per_sqft := i.land_rate_per_sqft,
+  on = .(meta_nbhd_code = meta_nbhd)
+][
+  ,
+  pred_pin_final_fmv_land := ceiling(fcase(
+    # nolint start
+    # Use fixed, flat, per site land values first. If the fixed flat land value
+    # exceeds the % of total FMV cap, set land FMV to the cap
+    !is.na(land_rate_per_pin) &
+      (land_rate_per_pin > pred_pin_final_fmv_round_no_prorate * params$pv$land_pct_of_total_cap),
+    pred_pin_final_fmv_round_no_prorate * params$pv$land_pct_of_total_cap,
+
+    # Otherwise, use the uncapped fixed land value
+    !is.na(land_rate_per_pin),
+    land_rate_per_pin,
+
+    # If no fixed site value exists, use the $/sqft rates. Again check against
+    # the % of FMV cap
+    char_land_sf * land_rate_per_sqft >= pred_pin_final_fmv_round_no_prorate * params$pv$land_pct_of_total_cap,
+    pred_pin_final_fmv_round_no_prorate * params$pv$land_pct_of_total_cap,
+
+    # If the total land value doesn't exceed the cap, then just use the $/sqft
+    rep(TRUE, .N),
+    char_land_sf * land_rate_per_sqft
+    # nolint end
+  ))
+][
+  ,
+  # Keep the uncapped value for display in desk review
+  pred_pin_uncapped_fmv_land := ceiling(fcase(
+    !is.na(land_rate_per_pin),
+    land_rate_per_pin,
+    rep(TRUE, .N),
+    char_land_sf * land_rate_per_sqft
+  ))
+]
 
 
 
@@ -204,106 +226,122 @@ message("Prorating buildings")
 
 # Prorating is the process of dividing a building's value among multiple PINs.
 # See the steps outlined below for the process to determine a prorated value:
-assessment_pin_data_prorated <- assessment_pin_data_w_land %>%
-  group_by(meta_tieback_key_pin) %>%
-  mutate(sum_pred_pin_final_fmv_land = sum(pred_pin_final_fmv_land)) %>%
-  ungroup() %>%
-  mutate(
-    tieback_total_land_fmv = ifelse(
-      is.na(meta_tieback_key_pin),
-      pred_pin_final_fmv_land,
-      sum_pred_pin_final_fmv_land
-    )
-  ) %>%
-  select(-sum_pred_pin_final_fmv_land) %>%
-  mutate(
-    # 1. Subtract the TOTAL value of the land of all linked PINs. This leaves
-    # only the value of the building that spans the PINs
-    pred_pin_final_fmv_bldg_no_prorate =
-      pred_pin_final_fmv_round_no_prorate - tieback_total_land_fmv,
-    # 2. Multiply the building by the proration rate of each PIN/card. This is
-    # the proportion of the building's value held by each PIN
-    pred_pin_final_fmv_bldg =
-      pred_pin_final_fmv_bldg_no_prorate * meta_tieback_proration_rate,
-    temp_bldg_frac_prop =
-      pred_pin_final_fmv_bldg - as.integer(pred_pin_final_fmv_bldg)
-  ) %>%
+assessment_pin_data_prorated <- copy(assessment_pin_data_w_land)[
+  !is.na(meta_tieback_key_pin),
+  tieback_total_land_fmv := sum(pred_pin_final_fmv_land),
+  by = .(meta_tieback_key_pin)
+][
+  is.na(meta_tieback_key_pin),
+  tieback_total_land_fmv := pred_pin_final_fmv_land,
+][
+  ,
+  # 1. Subtract the TOTAL value of the land of all linked PINs. This leaves
+  # only the value of the building that spans the PINs
+  pred_pin_final_fmv_bldg_no_prorate :=
+    pred_pin_final_fmv_round_no_prorate - tieback_total_land_fmv
+][
+  ,
+  # 2. Multiply the building by the proration rate of each PIN/card. This is
+  # the proportion of the building's value held by each PIN
+  pred_pin_final_fmv_bldg :=
+    pred_pin_final_fmv_bldg_no_prorate * meta_tieback_proration_rate,
+][
+  ,
+  temp_bldg_frac_prop :=
+    pred_pin_final_fmv_bldg - as.integer(pred_pin_final_fmv_bldg)
+][
+  order(meta_tieback_key_pin, -temp_bldg_frac_prop),
+][
+  ,
   # 3. Assign the fractional portion of a building (cents) to whichever portion
   # is largest i.e. [1.59, 1.41] becomes [2, 1]
-  group_by(meta_tieback_key_pin) %>%
-  arrange(desc(temp_bldg_frac_prop)) %>%
-  mutate(
-    temp_add_to_final = as.numeric(
-      n() > 1 & row_number() == 1 & temp_bldg_frac_prop > 0.1e-7
-    ),
-    temp_add_diff = temp_add_to_final * round(
-      sum(pred_pin_final_fmv_bldg, na.rm = TRUE) -
-        sum(as.integer(pred_pin_final_fmv_bldg), na.rm = TRUE)
-    ),
-    pred_pin_final_fmv_bldg = as.integer(pred_pin_final_fmv_bldg) +
-      temp_add_diff
-  ) %>%
-  ungroup() %>%
-  select(-starts_with("temp_")) %>%
-  mutate(
-    # 4. To get the total value of the individual PINs, add the individual land
-    # value of the PINs back to the prorated building value
-    pred_pin_final_fmv_round =
-      pred_pin_final_fmv_bldg + pred_pin_final_fmv_land
-  )
+  temp_add_to_final := as.numeric(
+    .N > 1 & seq_len(.N) == 1 & temp_bldg_frac_prop > 0.1e-7
+  ),
+  by = meta_tieback_key_pin
+][
+  ,
+  temp_add_diff := temp_add_to_final * round(
+    sum(pred_pin_final_fmv_bldg, na.rm = TRUE) -
+      sum(as.integer(pred_pin_final_fmv_bldg), na.rm = TRUE)
+  ),
+  by = .(meta_tieback_key_pin)
+][
+  ,
+  pred_pin_final_fmv_bldg := as.integer(pred_pin_final_fmv_bldg) +
+    temp_add_diff
+][
+  ,
+  # 4. To get the total value of the individual PINs, add the individual land
+  # value of the PINs back to the prorated building value
+  pred_pin_final_fmv_round :=
+    pred_pin_final_fmv_bldg + pred_pin_final_fmv_land
+][
+  ,
+  c("temp_bldg_frac_prop", "temp_add_to_final", "temp_add_diff") := NULL
+][
+  order(meta_pin),
+]
 
 # Merge the final PIN-level data back to the main tibble of predictions
-assessment_card_data_merged <- assessment_pin_data_prorated %>%
-  select(
+assessment_card_data_merged <- assessment_pin_data_prorated[
+  ,
+  .(
     meta_year, meta_pin, meta_complex_id,
     pred_pin_final_fmv, pred_pin_final_fmv_round_no_prorate,
     land_rate_per_pin, land_rate_per_sqft, pred_pin_uncapped_fmv_land,
     pred_pin_final_fmv_land, pred_pin_final_fmv_bldg_no_prorate,
     pred_pin_final_fmv_bldg, pred_pin_final_fmv_round
-  ) %>%
-  left_join(
-    assessment_card_data_pred,
-    by = c("meta_year", "meta_pin"),
-    multiple = "all"
-  ) %>%
-  mutate(
+  )
+][
+  assessment_card_data_pred,
+  on = .(meta_year, meta_pin)
+][
+  ,
+  `:=`(
     township_code = meta_township_code,
     meta_year = as.character(meta_year)
-  ) %>%
+  )
+][
+  ,
   # Apportion the final prorated PIN-level value back out to the card-level
   # using the square footage of each improvement
-  group_by(meta_year, meta_pin) %>%
-  mutate(
-    sum_char_bldg_sf = sum(char_bldg_sf),
-    pin_year_count = n()
-  ) %>%
-  ungroup() %>%
-  mutate(
-    meta_card_pct_total_fmv = char_bldg_sf / sum_char_bldg_sf,
-    # In cases where bldg sqft is missing (rare), fill evenly across cards
-    meta_card_pct_total_fmv = ifelse(
-      is.na(meta_card_pct_total_fmv),
-      1 / pin_year_count,
-      meta_card_pct_total_fmv
-    ),
-    pred_card_final_fmv = pred_pin_final_fmv_bldg * meta_card_pct_total_fmv,
-    temp_card_frac_prop = pred_card_final_fmv - as.integer(pred_card_final_fmv)
-  ) %>%
+  meta_card_pct_total_fmv := char_bldg_sf / sum(char_bldg_sf),
+  by = .(meta_year, meta_pin)
+][
+  # In cases where bldg sqft is missing (rare), fill evenly across cards
+  is.na(meta_card_pct_total_fmv),
+  meta_card_pct_total_fmv := 1 / .N,
+  by = .(meta_year, meta_pin)
+][
+  ,
+  pred_card_final_fmv := pred_pin_final_fmv_bldg * meta_card_pct_total_fmv,
+][
+  ,
+  temp_card_frac_prop := pred_card_final_fmv - as.integer(pred_card_final_fmv)
+][
+  order(meta_year, meta_pin, -temp_card_frac_prop),
+][
+  ,
   # More fractional rounding to deal with card values being split into cents
-  group_by(meta_year, meta_pin) %>%
-  arrange(desc(temp_card_frac_prop)) %>%
-  mutate(
-    temp_add_to_final = as.numeric(
-      n() > 1 & row_number() == 1 & temp_card_frac_prop > 0.1e-7
-    ),
-    temp_add_diff = temp_add_to_final * (
-      sum(pred_card_final_fmv, na.rm = TRUE) -
-        sum(as.integer(pred_card_final_fmv), na.rm = TRUE)
-    ),
-    pred_card_final_fmv = round(as.integer(pred_card_final_fmv) + temp_add_diff)
-  ) %>%
-  ungroup() %>%
-  select(-starts_with("temp_"))
+  temp_add_to_final := as.numeric(
+    .N > 1 & seq_len(.N) == 1 & temp_card_frac_prop > 0.1e-7
+  ),
+  by = .(meta_year, meta_pin)
+][
+  ,
+  temp_add_diff := temp_add_to_final * (
+    sum(pred_card_final_fmv, na.rm = TRUE) -
+      sum(as.integer(pred_card_final_fmv), na.rm = TRUE)
+  ),
+  by = .(meta_year, meta_pin)
+][
+  ,
+  pred_card_final_fmv := round(as.integer(pred_card_final_fmv) + temp_add_diff)
+][
+  ,
+  c("temp_card_frac_prop", "temp_add_to_final", "temp_add_diff") := NULL
+]
 
 # The test PINs below can be used to ensure that the order of operations
 # for the adjustments above results in a sensible outcome:
@@ -321,6 +359,7 @@ message("Saving card-level data")
 # Keep only card-level variables of interest, including: ID variables (run_id,
 # pin, card), characteristics, and predictions
 assessment_card_data_merged %>%
+  as_tibble() %>%
   select(
     meta_year, meta_pin, meta_class, meta_card_num, meta_card_pct_total_fmv,
     meta_complex_id, pred_card_initial_fmv, pred_card_final_fmv,
@@ -350,36 +389,79 @@ message("Attaching recent sales to PIN-level data")
 # Load the MOST RECENT sale per PIN from the year prior to the assessment year.
 # These are the sales that will be used for ratio studies in the evaluate stage.
 # We want our assessed value to be as close as possible to this sale
-sales_data_ratio_study <- sales_data %>%
-  filter(meta_year == params$assessment$data_year) %>%
-  group_by(meta_pin) %>%
-  filter(meta_sale_date == max(meta_sale_date)) %>%
-  distinct(
-    meta_pin, meta_year,
+sales_data_cols <- c(
+  "meta_pin", "meta_year", "sale_ratio_study_price",
+  "sale_ratio_study_date", "sale_ratio_study_document_num"
+)
+
+sales_data_ratio_study <- copy(sales_data)[
+  meta_year == params$assessment$data_year
+][
+  ,
+  max_sale_date := max(meta_sale_date),
+  by = .(meta_pin)
+][
+  meta_sale_date == max_sale_date
+][
+  ,
+  `:=`(
     sale_ratio_study_price = meta_sale_price,
     sale_ratio_study_date = meta_sale_date,
     sale_ratio_study_document_num = meta_sale_document_num
-  ) %>%
-  ungroup()
+  )
+][, ..sales_data_cols]
+
+sales_data_ratio_study <- unique(
+  sales_data_ratio_study,
+  by = sales_data_cols
+)
 
 # Keep the two most recent sales for each PIN from any year. These are just for
 # review, not for ratio studies
-sales_data_two_most_recent <- sales_data %>%
-  group_by(meta_pin) %>%
-  slice_max(meta_sale_date, n = 2) %>%
-  distinct(
-    meta_pin, meta_year,
-    meta_sale_price, meta_sale_date, meta_sale_document_num
-  ) %>%
-  mutate(mr = paste0("sale_recent_", row_number())) %>%
-  tidyr::pivot_wider(
-    id_cols = meta_pin,
-    names_from = mr,
-    values_from = c(meta_sale_date, meta_sale_price, meta_sale_document_num),
-    names_glue = "{mr}_{gsub('meta_sale_', '', .value)}"
-  ) %>%
-  select(meta_pin, contains("1"), contains("2")) %>%
-  ungroup()
+sales_data_two_cols <- c(
+  "meta_pin", "meta_year", "meta_sale_price",
+  "meta_sale_date", "meta_sale_document_num"
+)
+
+sales_data_two_idx <- unique(sales_data, by = sales_data_two_cols)[
+  ,
+  .I[order(-as.integer(meta_sale_date))][1:2],
+  by = .(meta_pin)
+]
+
+sales_data_two_temp <- unique(sales_data, by = sales_data_two_cols)[
+  sales_data_two_idx$V1
+][
+  !is.na(meta_pin)
+][
+  , ..sales_data_two_cols
+][
+  ,
+  mr := paste0("sale_recent_", seq_len(.N)),
+  by = .(meta_pin)
+]
+
+sales_data_two_most_recent <- dcast(
+  sales_data_two_temp,
+  meta_pin ~ mr,
+  value.var = c("meta_sale_date", "meta_sale_price", "meta_sale_document_num")
+)
+setnames(
+  sales_data_two_most_recent,
+  c(
+    "meta_pin", "sale_recent_1_date", "sale_recent_2_date",
+    "sale_recent_1_price", "sale_recent_2_price",
+    "sale_recent_1_document_num", "sale_recent_2_document_num"
+  )
+)
+setcolorder(
+  sales_data_two_most_recent,
+  c(
+    "meta_pin", "sale_recent_1_date", "sale_recent_1_price",
+    "sale_recent_1_document_num", "sale_recent_2_date",
+    "sale_recent_2_price", "sale_recent_2_document_num"
+  )
+)
 
 
 ## 7.2. Collapse to PIN Level --------------------------------------------------
@@ -387,120 +469,154 @@ message("Collapsing card-level data to PIN level")
 
 # Collapse card-level data to the PIN level, keeping the largest building on
 # each PIN but summing the total square footage of all buildings
-assessment_pin_data_base <- assessment_card_data_merged %>%
-  group_by(meta_year, meta_pin) %>%
-  arrange(desc(char_bldg_sf)) %>%
-  mutate(
-    # Keep the sum of the initial card level values
+assessment_pin_data_base <- copy(assessment_card_data_merged)[
+  ,
+  `:=`(
     pred_pin_initial_fmv = sum(pred_card_initial_fmv),
     char_total_bldg_sf = sum(char_bldg_sf, na.rm = TRUE)
-  ) %>%
-  filter(row_number() == 1) %>%
-  # Rename prior year comparison columns to near/far to maintain consistent
-  # column names in Athena
-  rename_with(
-    .fn = ~ gsub(paste0(rsn_prefix, "_"), "prior_near_", .x),
-    .cols = starts_with(rsn_prefix)
-  ) %>%
-  rename_with(
-    .fn = ~ gsub(paste0(rsf_prefix, "_"), "prior_far_", .x),
-    .cols = starts_with(rsf_prefix)
-  ) %>%
-  ungroup() %>%
-  select(
-    # Keep ID and meta variables
-    meta_year, meta_pin, meta_triad_code, meta_township_code, meta_nbhd_code,
-    meta_tax_code, meta_class, meta_tieback_key_pin,
-    meta_tieback_proration_rate, meta_cdu, meta_pin_num_cards,
-    meta_pin_num_landlines, meta_complex_id,
+  ),
+  by = .(meta_year, meta_pin)
+]
+assessment_pin_data_idx <- assessment_pin_data_base[
+  ,
+  .I[order(-char_bldg_sf)][1],
+  by = .(meta_year, meta_pin)
+]
+assessment_pin_data_base <- assessment_pin_data_base[assessment_pin_data_idx$V1]
 
-    # Keep certain vital characteristics for the largest card on the PIN
-    char_yrblt, char_land_sf, char_ext_wall, char_type_resd, char_total_bldg_sf,
+setnames(assessment_pin_data_base, gsub(
+  paste0("^", rsn_prefix, "_"),
+  "prior_near_",
+  colnames(assessment_pin_data_base)
+))
+setnames(assessment_pin_data_base, gsub(
+  paste0("^", rsf_prefix, "_"),
+  "prior_far_",
+  colnames(assessment_pin_data_base)
+))
 
-    # Keep locations, prior year values, and indicators
-    loc_longitude, loc_latitude,
-    starts_with(c(
-      "loc_property_", "loc_cook_", "loc_chicago_", "loc_ward_",
-      "loc_census", "loc_school_", "prior_", "ind_"
-    )),
+assessment_pin_data_base <- assessment_pin_data_base[, .SD, .SDcols = c(
+  # Keep ID and meta variables
+  "meta_year", "meta_pin", "meta_triad_code", "meta_township_code",
+  "meta_nbhd_code", "meta_tax_code", "meta_class", "meta_tieback_key_pin",
+  "meta_tieback_proration_rate", "meta_cdu", "meta_pin_num_cards",
+  "meta_pin_num_landlines", "meta_complex_id",
 
-    # Keep HIE flag
-    hie_num_expired,
+  # Keep certain vital characteristics for the largest card on the PIN
+  "char_yrblt", "char_land_sf", "char_ext_wall",
+  "char_type_resd", "char_total_bldg_sf",
 
-    # Keep PIN-level predicted values and land rates
-    land_rate_per_pin, land_rate_per_sqft,
-    pred_pin_initial_fmv,
-    pred_pin_final_fmv, pred_pin_final_fmv_round_no_prorate,
-    pred_pin_uncapped_fmv_land, pred_pin_final_fmv_land,
-    pred_pin_final_fmv_bldg_no_prorate, pred_pin_final_fmv_bldg,
-    pred_pin_final_fmv_round, township_code
-  ) %>%
-  # Make a flag for any vital missing characteristics
-  bind_cols(
-    assessment_card_data_merged %>%
-      select(
-        meta_year, meta_pin,
-        char_yrblt, char_bldg_sf, char_land_sf, char_beds,
-        char_fbath, char_apts
-      ) %>%
-      mutate(ind_char_missing_critical_value = rowSums(is.na(.))) %>%
-      group_by(meta_year, meta_pin) %>%
-      summarize(
-        ind_char_missing_critical_value =
-          sum(ind_char_missing_critical_value) > 0
-      ) %>%
-      ungroup() %>%
-      select(ind_char_missing_critical_value)
-  )
+  # Keep locations, prior year values, and indicators
+  "loc_longitude", "loc_latitude",
+  unname(unlist(sapply(c(
+    "loc_property_", "loc_cook_", "loc_chicago_", "loc_ward_",
+    "loc_census_", "loc_school_", "prior_", "ind_"
+  ), grep, names(assessment_pin_data_base), value = TRUE))),
+
+  # Keep HIE flag
+  "hie_num_expired",
+
+  # Keep PIN-level predicted values and land rates
+  "land_rate_per_pin", "land_rate_per_sqft",
+  "pred_pin_initial_fmv",
+  "pred_pin_final_fmv", "pred_pin_final_fmv_round_no_prorate",
+  "pred_pin_uncapped_fmv_land", "pred_pin_final_fmv_land",
+  "pred_pin_final_fmv_bldg_no_prorate", "pred_pin_final_fmv_bldg",
+  "pred_pin_final_fmv_round", "township_code"
+)][
+  assessment_card_data_merged[
+    ,
+    .(
+      meta_year, meta_pin,
+      char_yrblt, char_bldg_sf, char_land_sf, char_beds,
+      char_fbath, char_apts
+    )
+  ][
+    ,
+    .(meta_year, meta_pin, ind_missing = rowSums(is.na(.SD)))
+  ][
+    ,
+    .(ind_char_missing_critical_value = sum(ind_missing) > 0),
+    by = .(meta_year, meta_pin)
+  ],
+  on = c("meta_year", "meta_pin")
+]
 
 
 ## 7.3. Attach Sales -----------------------------------------------------------
 message("Attaching and comparing sale values")
 
 # Attach sales data to the PIN-level data
-assessment_pin_data_sale <- assessment_pin_data_base %>%
-  left_join(sales_data_two_most_recent, by = "meta_pin") %>%
-  left_join(sales_data_ratio_study, by = c("meta_year", "meta_pin")) %>%
-  # Calculate effective land rates (rate with 50% cap) + the % of the PIN value
-  # dedicated to the building
-  mutate(
+assessment_pin_data_sale <- merge(
+  assessment_pin_data_base,
+  sales_data_two_most_recent,
+  by = "meta_pin", all.x = TRUE
+)
+assessment_pin_data_sale <- merge(
+  assessment_pin_data_sale,
+  sales_data_ratio_study,
+  by = c("meta_year", "meta_pin"), all.x = TRUE
+)
+ratio_cols <- grep("^prior_", names(assessment_pin_data_sale), value = TRUE)
+assessment_pin_data_sale[
+  ,
+  `:=`(
+    # Calculate effective land rates (rate with 50% cap) + the % of
+    # the PIN value dedicated to the building
     pred_pin_land_rate_effective = pred_pin_final_fmv_land / char_land_sf,
     pred_pin_bldg_rate_effective = pred_pin_final_fmv_bldg / char_total_bldg_sf,
     pred_pin_land_pct_total = pred_pin_final_fmv_land / pred_pin_final_fmv_round
-  ) %>%
+  ),
+][
+  ,
   # Convert prior values to FMV from AV, then calculate year-over-year
   # percent and nominal changes
-  mutate(
-    across(starts_with("prior_"), ~ .x * 10),
+  (ratio_cols) := lapply(.SD, "*", 10),
+  .SDcols = ratio_cols
+][
+  ,
+  `:=`(
     prior_far_yoy_change_nom = pred_pin_final_fmv_round - prior_far_tot,
-    prior_far_yoy_change_pct = prior_far_yoy_change_nom / prior_far_tot,
+    prior_far_yoy_change_pct =
+      (pred_pin_final_fmv_round - prior_far_tot) / prior_far_tot,
     prior_near_yoy_change_nom = pred_pin_final_fmv_round - prior_near_tot,
-    prior_near_yoy_change_pct = prior_near_yoy_change_nom / prior_near_tot
+    prior_near_yoy_change_pct =
+      (pred_pin_final_fmv_round - prior_near_tot) / prior_near_tot
   )
+]
 
 
 ## 7.4. Add Flags --------------------------------------------------------------
 message("Adding Desk Review flags")
 
-# Flags are used to identify PINs for potential desktop review
-assessment_pin_data_final <- assessment_pin_data_sale %>%
-  # Rename existing indicators to flags
-  rename_with(~ gsub("ind_", "flag_", .x), starts_with("ind_")) %>%
+# Add flags are used to identify PINs for potential desktop review
+assessment_pin_data_final <- copy(assessment_pin_data_sale)
+
+# Rename existing indicators to flags
+setnames(assessment_pin_data_final, gsub(
+  "^ind_", "flag_",
+  colnames(assessment_pin_data_final)
+))
+setnames(assessment_pin_data_final, "hie_num_expired", "flag_hie_num_expired")
+
+assessment_pin_data_final[
+  ,
   # Add flag for potential proration issues (rates don't sum to 1)
-  group_by(meta_tieback_key_pin) %>%
-  mutate(flag_proration_sum_not_1 = ifelse(
+  flag_proration_sum_not_1 := fifelse(
     !is.na(meta_tieback_key_pin),
     sum(meta_tieback_proration_rate) != 1,
     FALSE
-  )) %>%
-  ungroup() %>%
+  ),
+  by = .(meta_tieback_key_pin)
+][
+  ,
   # Flag for capped land value
-  mutate(
-    flag_land_value_capped = pred_pin_final_fmv_round *
-      params$pv$land_pct_of_total_cap == pred_pin_final_fmv_land
-  ) %>%
+  flag_land_value_capped := pred_pin_final_fmv_round *
+    params$pv$land_pct_of_total_cap == pred_pin_final_fmv_land
+][
+  ,
   # Flags for changes in values
-  mutate(
+  `:=`(
     flag_prior_near_to_pred_unchanged =
       prior_near_tot >= pred_pin_final_fmv_round - 100 &
         prior_near_tot <= pred_pin_final_fmv_round + 100, # nolint
@@ -511,19 +627,24 @@ assessment_pin_data_final <- assessment_pin_data_sale %>%
       type = params$pv$round_type
     ) != pred_pin_final_fmv_round,
     flag_prior_near_yoy_inc_gt_50_pct = prior_near_yoy_change_pct > 0.5,
-    flag_prior_near_yoy_dec_gt_5_pct = prior_near_yoy_change_pct < -0.05,
-  ) %>%
-  # Flag high-value properties from prior years
-  group_by(meta_township_code) %>%
-  mutate(flag_prior_near_fmv_top_decile = ntile(prior_near_tot, 10) == 10) %>%
-  ungroup() %>%
-  # Flags for HIEs / 288s (placeholder until 288 data is integrated)
-  rename(flag_hie_num_expired = hie_num_expired) %>%
-  mutate(
-    flag_hie_num_expired = tidyr::replace_na(flag_hie_num_expired, 0),
-    meta_pin_num_landlines = tidyr::replace_na(meta_pin_num_landlines, 1),
-    flag_pin_is_multiland = tidyr::replace_na(flag_pin_is_multiland, FALSE)
+    flag_prior_near_yoy_dec_gt_5_pct = prior_near_yoy_change_pct < -0.05
   )
+][
+  ,
+  # Flag high-value properties from prior years
+  flag_prior_near_fmv_top_decile := ntile(prior_near_tot, 10) == 10,
+  by = .(meta_township_code)
+][
+  ,
+  `:=`(
+    flag_hie_num_expired = nafill(flag_hie_num_expired, fill = 0),
+    meta_pin_num_landlines = nafill(meta_pin_num_landlines, fill = 1),
+    meta_complex_id = as.numeric(meta_complex_id)
+  )
+][
+  is.na(flag_pin_is_multiland),
+  flag_pin_is_multiland := FALSE
+]
 
 
 ## 7.5. Clean/Reorder/Save -----------------------------------------------------
@@ -536,7 +657,6 @@ assessment_pin_data_final %>%
     type = "short",
     as_factor = FALSE
   ) %>%
-  mutate(meta_complex_id = as.numeric(meta_complex_id)) %>%
   # Reorder columns into groups by prefix
   select(
     starts_with(c("meta_", "loc_")), char_yrblt, char_total_bldg_sf,

--- a/pipeline/03-evaluate.R
+++ b/pipeline/03-evaluate.R
@@ -12,9 +12,6 @@ tictoc::tic("Evaluate")
 # Load libraries, helpers, and recipes from files
 purrr::walk(list.files("R/", "\\.R$", full.names = TRUE), source)
 
-# Enable parallel backend for generating stats more quickly
-plan(multisession, workers = num_threads)
-
 # Renaming dictionary for input columns. We want the actual value of the column
 # to become geography_id and the NAME of the column to become geography_name
 col_rename_dict <- c(
@@ -83,22 +80,34 @@ gen_agg_stats <- function(data, truth, estimate, bldg_sqft,
   # Each function is listed on the right while the name of the function is on
   # the left
   rs_fns_list <- list(
-    cod_no_sop = ~ ifelse(sum(!is.na(.y)) > 1, cod(.x / .y, na.rm = TRUE), NA),
-    prd_no_sop = ~ ifelse(sum(!is.na(.y)) > 1, prd(.x, .y, na.rm = TRUE), NA),
-    prb_no_sop = ~ ifelse(sum(!is.na(.y)) > 1, prb(.x, .y, na.rm = TRUE), NA),
-    cod = ~ ifelse(
-      sum(!is.na(.y)) > 33,
-      list(ccao_cod(.x / .y, na.rm = TRUE)),
+    cod_no_sop = \(x, y) ifelse(
+      sum(!is.na(y)) > 1,
+      cod(x / y, na.rm = TRUE),
       NA
     ),
-    prd = ~ ifelse(
-      sum(!is.na(.y)) > 33,
-      list(ccao_prd(.x, .y, na.rm = TRUE)),
+    prd_no_sop = \(x, y) ifelse(
+      sum(!is.na(y)) > 1,
+      prd(x, y, na.rm = TRUE),
       NA
     ),
-    prb = ~ ifelse(
-      sum(!is.na(.y)) > 33,
-      list(ccao_prb(.x, .y, na.rm = TRUE)),
+    prb_no_sop = \(x, y) ifelse(
+      sum(!is.na(y)) > 1,
+      prb(x, y, na.rm = TRUE),
+      NA
+    ),
+    cod = \(x, y) ifelse(
+      sum(!is.na(y)) > 33,
+      list(ccao_cod(x / y, na.rm = TRUE)),
+      NA
+    ),
+    prd = \(x, y) ifelse(
+      sum(!is.na(y)) > 33,
+      list(ccao_prd(x, y, na.rm = TRUE)),
+      NA
+    ),
+    prb = \(x, y) ifelse(
+      sum(!is.na(y)) > 33,
+      list(ccao_prb(x, y, na.rm = TRUE)),
       NA
     )
   )
@@ -110,331 +119,416 @@ gen_agg_stats <- function(data, truth, estimate, bldg_sqft,
     mape        = mape_vec
   )
   sum_fns_list <- list(
-    min         = ~ min(.x, na.rm = TRUE),
-    q25         = ~ quantile(.x, na.rm = TRUE, probs = 0.25),
-    median      = ~ median(.x, na.rm = TRUE),
-    q75         = ~ quantile(.x, na.rm = TRUE, probs = 0.75),
-    max         = ~ max(.x, na.rm = TRUE)
+    min         = \(x) min(x, na.rm = TRUE),
+    q25         = \(x) quantile(x, na.rm = TRUE, probs = 0.25),
+    median      = \(x) median(x, na.rm = TRUE),
+    q75         = \(x) quantile(x, na.rm = TRUE, probs = 0.75),
+    max         = \(x) max(x, na.rm = TRUE)
   )
   sum_sqft_fns_list <- list(
-    min         = ~ min(.x / .y, na.rm = TRUE),
-    q25         = ~ quantile(.x / .y, na.rm = TRUE, probs = 0.25),
-    median      = ~ median(.x / .y, na.rm = TRUE),
-    q75         = ~ quantile(.x / .y, na.rm = TRUE, probs = 0.75),
-    max         = ~ max(.x / .y, na.rm = TRUE)
+    min         = \(x, y) min(x / y, na.rm = TRUE),
+    q25         = \(x, y) quantile(x / y, na.rm = TRUE, probs = 0.25),
+    median      = \(x, y) median(x / y, na.rm = TRUE),
+    q75         = \(x, y) quantile(x / y, na.rm = TRUE, probs = 0.75),
+    max         = \(x, y) max(x / y, na.rm = TRUE)
   )
   yoy_fns_list <- list(
-    min         = ~ min((.x - .y) / .y, na.rm = TRUE),
-    q25         = ~ quantile((.x - .y) / .y, na.rm = TRUE, probs = 0.25),
-    median      = ~ median((.x - .y) / .y, na.rm = TRUE),
-    q75         = ~ quantile((.x - .y) / .y, na.rm = TRUE, probs = 0.75),
-    max         = ~ max((.x - .y) / .y, na.rm = TRUE)
+    min         = \(x, y) min((x - .) / .y, na.rm = TRUE),
+    q25         = \(x, y) quantile((x - y) / .y, na.rm = TRUE, probs = 0.25),
+    median      = \(x, y) median((x - y) / .y, na.rm = TRUE),
+    q75         = \(x, y) quantile((x - y) / .y, na.rm = TRUE, probs = 0.75),
+    max         = \(x, y) max((x - y) / y, na.rm = TRUE)
   )
 
   # Generate aggregate performance stats by geography
-  df_stat <- data %>%
+  df_stat <- as.data.table(data)[
+    ,
     # Aggregate to get counts by geography without class
-    group_by({{ triad }}, {{ geography }}) %>%
-    mutate(
-      num_pin_no_class = n(),
-      num_sale_no_class = sum(!is.na({{ truth }}))
-    ) %>%
-    # Aggregate including class
-    group_by({{ triad }}, {{ geography }}, {{ class }}) %>%
-    summarize(
+    `:=`(
+      num_pin_no_class = .N,
+      num_sale_no_class = sum(!is.na(get(truth)))
+    ),
+    by = c(triad, geography)
+  ][
+    ,
+    {
+      # Variables that get re-used inside the brackets are specified here
+      num_pin <- .N
+      num_sale <- sum(!is.na(get(truth)))
 
+      # Aggregate to get counts by geography and class
       # Basic summary stats, counts, proportions, etc
-      num_pin = n(),
-      num_sale = sum(!is.na({{ truth }})),
-      pct_of_total_pin_by_class = num_pin / first(num_pin_no_class),
-      pct_of_total_sale_by_class = num_sale / first(num_sale_no_class),
-      pct_of_pin_sold = num_sale / num_pin,
-      prior_far_total_av = sum({{ rsf_col }} / 10, na.rm = TRUE),
-      prior_near_total_av = sum({{ rsn_col }} / 10, na.rm = TRUE),
-      estimate_total_av = sum({{ estimate }} / 10, na.rm = TRUE),
+      purrr::list_flatten(list(
+        num_pin = num_pin,
+        num_sale = num_sale,
+        pct_of_total_pin_by_class = num_pin /
+          data.table::first(num_pin_no_class),
+        pct_of_total_sale_by_class = num_sale /
+          data.table::first(num_sale_no_class),
+        pct_of_pin_sold = num_sale / num_pin,
+        prior_far_total_av = sum(get(rsf_col) / 10, na.rm = TRUE),
+        prior_near_total_av = sum(get(rsn_col) / 10, na.rm = TRUE),
+        estimate_total_av = sum(get(estimate) / 10, na.rm = TRUE),
 
-      # Assessment-specific statistics
-      across(
-        .fns = rs_fns_list, {{ estimate }}, {{ truth }},
-        .names = "{.fn}"
-      ),
-      median_ratio = median({{ estimate }} / {{ truth }}, na.rm = TRUE),
+        # Assessment-specific statistics
+        imap(rs_fns_list, ~ rlang::exec(.x, get(estimate), get(truth))),
+        median_ratio = median(get(estimate) / get(truth), na.rm = TRUE),
 
-      # Yardstick (ML-specific) performance stats
-      across(.fns = ys_fns_list, {{ truth }}, {{ estimate }}, .names = "{.fn}"),
+        # Yardstick (ML-specific) performance stats
+        imap(ys_fns_list, ~ rlang::exec(.x, get(truth), get(estimate))),
 
-      # Summary stats of sale price and sale price per sqft
-      across(.fns = sum_fns_list, {{ truth }}, .names = "sale_fmv_{.fn}"),
-      across(
-        .fns = sum_sqft_fns_list, {{ truth }}, {{ bldg_sqft }},
-        .names = "sale_fmv_per_sqft_{.fn}"
-      ),
+        # Summary stats of sale price and sale price per sqft
+        imap(sum_fns_list, ~ rlang::exec(.x, get(truth))) %>%
+          purrr::set_names(paste0("sale_fmv_", names(.))),
+        imap(
+          sum_sqft_fns_list,
+          ~ rlang::exec(.x, get(truth), get(bldg_sqft))
+        ) %>%
+          purrr::set_names(paste0("sale_fmv_per_sqft_", names(.)))
+        #
+        #     # Summary stats of prior values and value per sqft. Need to mult
+        #     # by 10 first since PIN history is in AV, not FMV
+        #     prior_far_num_missing = sum(is.na({{ rsf_col }})),
+        #     across(
+        #       .fns = sum_fns_list, {{ rsf_col }},
+        #       .names = "prior_far_fmv_{.fn}"
+        #     ),
+        #     across(
+        #       .fns = sum_sqft_fns_list, {{ rsf_col }}, {{ bldg_sqft }},
+        #       .names = "prior_far_fmv_per_sqft_{.fn}"
+        #     ),
+        #     across(
+        #       .fns = yoy_fns_list, {{ estimate }}, {{ rsf_col }},
+        #       .names = "prior_far_yoy_pct_chg_{.fn}"
+        #     ),
+        #     prior_near_num_missing = sum(is.na({{ rsn_col }})),
+        #     across(
+        #       .fns = sum_fns_list, {{ rsn_col }},
+        #       .names = "prior_near_fmv_{.fn}"
+        #     ),
+        #     across(
+        #       .fns = sum_sqft_fns_list, {{ rsn_col }}, {{ bldg_sqft }},
+        #       .names = "prior_near_fmv_per_sqft_{.fn}"
+        #     ),
+        #     across(
+        #       .fns = yoy_fns_list, {{ estimate }}, {{ rsn_col }},
+        #       .names = "prior_near_yoy_pct_chg_{.fn}"
+        #     ),
+        #
+        #     # Summary stats of estimate value and estimate per sqft
+        #     estimate_num_missing = sum(is.na({{ estimate }})),
+        #     across(
+        #       .fns = sum_fns_list, {{ estimate }},
+        #       .names = "estimate_fmv_{.fn}"
+        #     ),
+        #     across(
+        #       .fns = sum_sqft_fns_list, {{ estimate }}, {{ bldg_sqft }},
+        #       .names = "estimate_fmv_per_sqft_{.fn}"
+        #     ),
+      ))
+    },
+    by = c(triad, geography, class)
+  ]
 
-      # Summary stats of prior values and value per sqft. Need to multiply
-      # by 10 first since PIN history is in AV, not FMV
-      prior_far_num_missing = sum(is.na({{ rsf_col }})),
-      across(
-        .fns = sum_fns_list, {{ rsf_col }},
-        .names = "prior_far_fmv_{.fn}"
-      ),
-      across(
-        .fns = sum_sqft_fns_list, {{ rsf_col }}, {{ bldg_sqft }},
-        .names = "prior_far_fmv_per_sqft_{.fn}"
-      ),
-      across(
-        .fns = yoy_fns_list, {{ estimate }}, {{ rsf_col }},
-        .names = "prior_far_yoy_pct_chg_{.fn}"
-      ),
-      prior_near_num_missing = sum(is.na({{ rsn_col }})),
-      across(
-        .fns = sum_fns_list, {{ rsn_col }},
-        .names = "prior_near_fmv_{.fn}"
-      ),
-      across(
-        .fns = sum_sqft_fns_list, {{ rsn_col }}, {{ bldg_sqft }},
-        .names = "prior_near_fmv_per_sqft_{.fn}"
-      ),
-      across(
-        .fns = yoy_fns_list, {{ estimate }}, {{ rsn_col }},
-        .names = "prior_near_yoy_pct_chg_{.fn}"
-      ),
+  return(df_stat)
 
-      # Summary stats of estimate value and estimate per sqft
-      estimate_num_missing = sum(is.na({{ estimate }})),
-      across(
-        .fns = sum_fns_list, {{ estimate }},
-        .names = "estimate_fmv_{.fn}"
-      ),
-      across(
-        .fns = sum_sqft_fns_list, {{ estimate }}, {{ bldg_sqft }},
-        .names = "estimate_fmv_per_sqft_{.fn}"
-      ),
-      .groups = "drop"
-    ) %>%
-    ungroup() %>%
-    # COD, PRD, and PRB all output to a list. We can unnest each list to get
-    # additional info for each stat (95% CI, sample count, etc)
-    tidyr::unnest_wider(cod) %>%
-    tidyr::unnest_wider(COD_CI, names_sep = "_") %>%
-    tidyr::unnest_wider(prd) %>%
-    tidyr::unnest_wider(PRD_CI, names_sep = "_") %>%
-    tidyr::unnest_wider(prb) %>%
-    tidyr::unnest_wider(PRB_CI, names_sep = "_") %>%
-    # Rename columns resulting from unnesting
-    rename_with(~ gsub("%", "", gsub("\\.", "_", tolower(.x))))
-
-  # Clean up the stats output (rename cols, relocate cols, etc.)
-  df_stat %>%
-    mutate(
-      by_class = !is.null({{ class }}),
-      geography_type = ifelse(
-        !is.null({{ geography }}),
-        ccao::vars_rename(
-          rlang::as_string(rlang::ensym(geography)),
-          names_from = "model",
-          names_to = "athena"
-        ),
-        "triad_code"
-      )
-    ) %>%
-    rename(any_of(col_dict)) %>%
-    relocate(
-      any_of(c("geography_type", "geography_id", "by_class", "class")),
-      .after = "triad_code"
-    ) %>%
-    mutate(across(
-      -(contains("_max") & contains("yoy")) & where(is.numeric),
-      ~ replace(.x, !is.finite(.x), NA)
-    ))
+  #     # Assessment-specific statistics
+  #     across(
+  #       .fns = rs_fns_list, {{ estimate }}, {{ truth }},
+  #       .names = "{.fn}"
+  #     ),
+  #     median_ratio = median({{ estimate }} / {{ truth }}, na.rm = TRUE),
+  #
+  #     # Yardstick (ML-specific) performance stats
+  #     across(.fns = ys_fns_list, {{ truth }}, {{ estimate }}, .names = "{.fn}"),
+  #
+  #     # Summary stats of sale price and sale price per sqft
+  #     across(.fns = sum_fns_list, {{ truth }}, .names = "sale_fmv_{.fn}"),
+  #     across(
+  #       .fns = sum_sqft_fns_list, {{ truth }}, {{ bldg_sqft }},
+  #       .names = "sale_fmv_per_sqft_{.fn}"
+  #     ),
+  #
+  #     # Summary stats of prior values and value per sqft. Need to multiply
+  #     # by 10 first since PIN history is in AV, not FMV
+  #     prior_far_num_missing = sum(is.na({{ rsf_col }})),
+  #     across(
+  #       .fns = sum_fns_list, {{ rsf_col }},
+  #       .names = "prior_far_fmv_{.fn}"
+  #     ),
+  #     across(
+  #       .fns = sum_sqft_fns_list, {{ rsf_col }}, {{ bldg_sqft }},
+  #       .names = "prior_far_fmv_per_sqft_{.fn}"
+  #     ),
+  #     across(
+  #       .fns = yoy_fns_list, {{ estimate }}, {{ rsf_col }},
+  #       .names = "prior_far_yoy_pct_chg_{.fn}"
+  #     ),
+  #     prior_near_num_missing = sum(is.na({{ rsn_col }})),
+  #     across(
+  #       .fns = sum_fns_list, {{ rsn_col }},
+  #       .names = "prior_near_fmv_{.fn}"
+  #     ),
+  #     across(
+  #       .fns = sum_sqft_fns_list, {{ rsn_col }}, {{ bldg_sqft }},
+  #       .names = "prior_near_fmv_per_sqft_{.fn}"
+  #     ),
+  #     across(
+  #       .fns = yoy_fns_list, {{ estimate }}, {{ rsn_col }},
+  #       .names = "prior_near_yoy_pct_chg_{.fn}"
+  #     ),
+  #
+  #     # Summary stats of estimate value and estimate per sqft
+  #     estimate_num_missing = sum(is.na({{ estimate }})),
+  #     across(
+  #       .fns = sum_fns_list, {{ estimate }},
+  #       .names = "estimate_fmv_{.fn}"
+  #     ),
+  #     across(
+  #       .fns = sum_sqft_fns_list, {{ estimate }}, {{ bldg_sqft }},
+  #       .names = "estimate_fmv_per_sqft_{.fn}"
+  #     ),
+  #     .groups = "drop"
+  #   ) %>%
+  #   ungroup() %>%
+  #   # COD, PRD, and PRB all output to a list. We can unnest each list to get
+  #   # additional info for each stat (95% CI, sample count, etc)
+  #   tidyr::unnest_wider(cod) %>%
+  #   tidyr::unnest_wider(COD_CI, names_sep = "_") %>%
+  #   tidyr::unnest_wider(prd) %>%
+  #   tidyr::unnest_wider(PRD_CI, names_sep = "_") %>%
+  #   tidyr::unnest_wider(prb) %>%
+  #   tidyr::unnest_wider(PRB_CI, names_sep = "_") %>%
+  #   # Rename columns resulting from unnesting
+  #   rename_with(~ gsub("%", "", gsub("\\.", "_", tolower(.x))))
+  #
+  # # Clean up the stats output (rename cols, relocate cols, etc.)
+  # df_stat %>%
+  #   mutate(
+  #     by_class = !is.null({{ class }}),
+  #     geography_type = ifelse(
+  #       !is.null({{ geography }}),
+  #       ccao::vars_rename(
+  #         rlang::as_string(rlang::ensym(geography)),
+  #         names_from = "model",
+  #         names_to = "athena"
+  #       ),
+  #       "triad_code"
+  #     )
+  #   ) %>%
+  #   rename(any_of(col_dict)) %>%
+  #   relocate(
+  #     any_of(c("geography_type", "geography_id", "by_class", "class")),
+  #     .after = "triad_code"
+  #   ) %>%
+  #   mutate(across(
+  #     -(contains("_max") & contains("yoy")) & where(is.numeric),
+  #     ~ replace(.x, !is.finite(.x), NA)
+  #   ))
 }
 
-
-# Same as the gen_agg_stats function, but with different statistics and broken
-# out by quantile
-gen_agg_stats_quantile <- function(data, truth, estimate,
-                                   rsn_col, rsf_col, triad, geography,
-                                   class, col_dict, num_quantile) {
-  # Calculate the median ratio by quantile of sale price, plus the upper and
-  # lower bounds of each quantile
-  df_quantile <- data %>%
-    group_by({{ triad }}, {{ geography }}, {{ class }}) %>%
-    mutate(quantile = ntile({{ truth }}, n = num_quantile)) %>%
-    group_by({{ triad }}, {{ geography }}, {{ class }}, quantile) %>%
-    summarize(
-      num_sale = sum(!is.na({{ truth }})),
-      median_ratio = median(({{ estimate }} / {{ truth }}), na.rm = TRUE),
-      lower_bound = min({{ truth }}, na.rm = TRUE),
-      upper_bound = max({{ truth }}, na.rm = TRUE),
-      prior_near_yoy_pct_chg_median = median(
-        ({{ estimate }} - {{ rsn_col }}) / {{ rsn_col }},
-        na.rm = TRUE
-      ),
-      prior_far_yoy_pct_chg_median = median(
-        ({{ estimate }} - {{ rsf_col }}) / {{ rsf_col }},
-        na.rm = TRUE
-      ),
-      .groups = "drop"
-    ) %>%
-    ungroup()
-
-  # Clean up the quantile output
-  df_quantile %>%
-    mutate(
-      num_quantile = num_quantile,
-      by_class = !is.null({{ class }}),
-      geography_type = ifelse(
-        !is.null({{ geography }}),
-        ccao::vars_rename(
-          rlang::as_string(rlang::ensym(geography)),
-          names_from = "model",
-          names_to = "athena"
-        ),
-        "triad_code"
-      )
-    ) %>%
-    filter(!is.na(quantile)) %>%
-    rename(any_of(col_dict)) %>%
-    relocate(
-      any_of(c(
-        "geography_type", "geography_id",
-        "by_class", "class", "num_quantile"
-      )),
-      .after = "triad_code"
-    ) %>%
-    mutate(across(
-      -(contains("_max") & contains("yoy")) & where(is.numeric),
-      ~ replace(.x, !is.finite(.x), NA)
-    ))
-}
-
-
-
-
-#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-# 4. Generate Stats ------------------------------------------------------------
-#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
-# Use fancy tidyeval to create a list of all the geography levels with a
-# class or no class option for each level
-geographies_quosures <- rlang::quos(
-  meta_township_code,
-  meta_nbhd_code, loc_cook_municipality_name,
-  loc_ward_num, loc_census_puma_geoid, loc_census_tract_geoid,
-  loc_school_elementary_district_geoid, loc_school_secondary_district_geoid,
-  loc_school_unified_district_geoid,
-  NULL
-)
-geographies_list <- purrr::cross2(
-  geographies_quosures,
-  rlang::quos(meta_class, NULL)
-)
-
-# Same as above, but add quantile breakouts to the grid expansion
-geographies_list_quantile <- purrr::cross3(
-  geographies_quosures,
-  rlang::quos(meta_class, NULL),
-  params$ratio_study$num_quantile
+meta_township_code <- gen_agg_stats(
+  data = assessment_data_pin,
+  truth = "sale_ratio_study_price",
+  estimate = "pred_pin_final_fmv_round",
+  bldg_sqft = "char_total_bldg_sf",
+  rsn_col = "prior_near_tot",
+  rsf_col = "prior_far_tot",
+  triad = "meta_triad_code",
+  geography = "meta_township_code",
+  class = NULL,
+  col_dict = col_rename_dict
 )
 
 
-## 4.1. Test Set ---------------------------------------------------------------
-
-# Use parallel map to calculate aggregate stats for every geography level and
-# class combination for the test set
-message("Calculating test set aggregate statistics")
-future_map_dfr(
-  geographies_list,
-  ~ gen_agg_stats(
-    data = test_data_card,
-    truth = meta_sale_price,
-    estimate = pred_card_initial_fmv,
-    bldg_sqft = char_bldg_sf,
-    rsn_col = prior_near_tot,
-    rsf_col = prior_far_tot,
-    triad = meta_triad_code,
-    geography = !!.x[[1]],
-    class = !!.x[[2]],
-    col_dict = col_rename_dict
-  ),
-  .options = furrr_options(seed = TRUE, stdout = FALSE),
-  .progress = FALSE
-) %>%
-  write_parquet(paths$output$performance_test$local)
-
-# Same as above, but calculate stats per quantile of sale price
-message("Calculating test set quantile statistics")
-future_map_dfr(
-  geographies_list_quantile,
-  ~ gen_agg_stats_quantile(
-    data = test_data_card,
-    truth = meta_sale_price,
-    estimate = pred_card_initial_fmv,
-    rsn_col = prior_near_tot,
-    rsf_col = prior_far_tot,
-    triad = meta_triad_code,
-    geography = !!.x[[1]],
-    class = !!.x[[2]],
-    col_dict = col_rename_dict,
-    num_quantile = .x[[3]]
-  ),
-  .options = furrr_options(seed = TRUE, stdout = FALSE),
-  .progress = FALSE
-) %>%
-  write_parquet(paths$output$performance_quantile_test$local)
-
-
-## 4.2. Assessment Set ---------------------------------------------------------
-
-# Only value the assessment set for full runs
-if (run_type == "full") {
-  # Do the same thing for the assessment set. This will have accurate property
-  # counts and proportions, since it also includes unsold properties
-  message("Calculating assessment set aggregate statistics")
-  future_map_dfr(
-    geographies_list,
-    ~ gen_agg_stats(
-      data = assessment_data_pin,
-      truth = sale_ratio_study_price,
-      estimate = pred_pin_final_fmv_round,
-      bldg_sqft = char_total_bldg_sf,
-      rsn_col = prior_near_tot,
-      rsf_col = prior_far_tot,
-      triad = meta_triad_code,
-      geography = !!.x[[1]],
-      class = !!.x[[2]],
-      col_dict = col_rename_dict
-    ),
-    .options = furrr_options(seed = TRUE, stdout = FALSE),
-    .progress = FALSE
-  ) %>%
-    write_parquet(paths$output$performance_assessment$local)
-
-  # Same as above, but calculate stats per quantile of sale price
-  message("Calculating assessment set quantile statistics")
-  future_map_dfr(
-    geographies_list_quantile,
-    ~ gen_agg_stats_quantile(
-      data = assessment_data_pin,
-      truth = sale_ratio_study_price,
-      estimate = pred_pin_final_fmv_round,
-      rsn_col = prior_near_tot,
-      rsf_col = prior_far_tot,
-      triad = meta_triad_code,
-      geography = !!.x[[1]],
-      class = !!.x[[2]],
-      col_dict = col_rename_dict,
-      num_quantile = .x[[3]]
-    ),
-    .options = furrr_options(seed = TRUE, stdout = FALSE),
-    .progress = FALSE
-  ) %>%
-    write_parquet(paths$output$performance_quantile_assessment$local)
-}
-
-# End the stage timer and write the time elapsed to a temporary file
-tictoc::toc(log = TRUE)
-bind_rows(tictoc::tic.log(format = FALSE)) %>%
-  arrow::write_parquet(gsub("//*", "/", file.path(
-    paths$intermediate$timing$local,
-    "model_timing_evaluate.parquet"
-  )))
+#
+#
+# # Same as the gen_agg_stats function, but with different statistics and broken
+# # out by quantile
+# gen_agg_stats_quantile <- function(data, truth, estimate,
+#                                    rsn_col, rsf_col, triad, geography,
+#                                    class, col_dict, num_quantile) {
+#   # Calculate the median ratio by quantile of sale price, plus the upper and
+#   # lower bounds of each quantile
+#   df_quantile <- data %>%
+#     group_by({{ triad }}, {{ geography }}, {{ class }}) %>%
+#     mutate(quantile = ntile({{ truth }}, n = num_quantile)) %>%
+#     group_by({{ triad }}, {{ geography }}, {{ class }}, quantile) %>%
+#     summarize(
+#       num_sale = sum(!is.na({{ truth }})),
+#       median_ratio = median(({{ estimate }} / {{ truth }}), na.rm = TRUE),
+#       lower_bound = min({{ truth }}, na.rm = TRUE),
+#       upper_bound = max({{ truth }}, na.rm = TRUE),
+#       prior_near_yoy_pct_chg_median = median(
+#         ({{ estimate }} - {{ rsn_col }}) / {{ rsn_col }},
+#         na.rm = TRUE
+#       ),
+#       prior_far_yoy_pct_chg_median = median(
+#         ({{ estimate }} - {{ rsf_col }}) / {{ rsf_col }},
+#         na.rm = TRUE
+#       ),
+#       .groups = "drop"
+#     ) %>%
+#     ungroup()
+#
+#   # Clean up the quantile output
+#   df_quantile %>%
+#     mutate(
+#       num_quantile = num_quantile,
+#       by_class = !is.null({{ class }}),
+#       geography_type = ifelse(
+#         !is.null({{ geography }}),
+#         ccao::vars_rename(
+#           rlang::as_string(rlang::ensym(geography)),
+#           names_from = "model",
+#           names_to = "athena"
+#         ),
+#         "triad_code"
+#       )
+#     ) %>%
+#     filter(!is.na(quantile)) %>%
+#     rename(any_of(col_dict)) %>%
+#     relocate(
+#       any_of(c(
+#         "geography_type", "geography_id",
+#         "by_class", "class", "num_quantile"
+#       )),
+#       .after = "triad_code"
+#     ) %>%
+#     mutate(across(
+#       -(contains("_max") & contains("yoy")) & where(is.numeric),
+#       ~ replace(.x, !is.finite(.x), NA)
+#     ))
+# }
+#
+#
+#
+#
+# #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# # 4. Generate Stats ------------------------------------------------------------
+# #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+#
+# # Use fancy tidyeval to create a list of all the geography levels with a
+# # class or no class option for each level
+# geographies_quosures <- rlang::quos(
+#   meta_township_code,
+#   meta_nbhd_code, loc_cook_municipality_name,
+#   loc_ward_num, loc_census_puma_geoid, loc_census_tract_geoid,
+#   loc_school_elementary_district_geoid, loc_school_secondary_district_geoid,
+#   loc_school_unified_district_geoid,
+#   NULL
+# )
+# geographies_list <- purrr::cross2(
+#   geographies_quosures,
+#   rlang::quos(meta_class, NULL)
+# )
+#
+# # Same as above, but add quantile breakouts to the grid expansion
+# geographies_list_quantile <- purrr::cross3(
+#   geographies_quosures,
+#   rlang::quos(meta_class, NULL),
+#   params$ratio_study$num_quantile
+# )
+#
+#
+# ## 4.1. Test Set ---------------------------------------------------------------
+#
+# # Use parallel map to calculate aggregate stats for every geography level and
+# # class combination for the test set
+# message("Calculating test set aggregate statistics")
+# future_map_dfr(
+#   geographies_list,
+#   ~ gen_agg_stats(
+#     data = test_data_card,
+#     truth = meta_sale_price,
+#     estimate = pred_card_initial_fmv,
+#     bldg_sqft = char_bldg_sf,
+#     rsn_col = prior_near_tot,
+#     rsf_col = prior_far_tot,
+#     triad = meta_triad_code,
+#     geography = !!.x[[1]],
+#     class = !!.x[[2]],
+#     col_dict = col_rename_dict
+#   ),
+#   .options = furrr_options(seed = TRUE, stdout = FALSE),
+#   .progress = FALSE
+# ) %>%
+#   write_parquet(paths$output$performance_test$local)
+#
+# # Same as above, but calculate stats per quantile of sale price
+# message("Calculating test set quantile statistics")
+# future_map_dfr(
+#   geographies_list_quantile,
+#   ~ gen_agg_stats_quantile(
+#     data = test_data_card,
+#     truth = meta_sale_price,
+#     estimate = pred_card_initial_fmv,
+#     rsn_col = prior_near_tot,
+#     rsf_col = prior_far_tot,
+#     triad = meta_triad_code,
+#     geography = !!.x[[1]],
+#     class = !!.x[[2]],
+#     col_dict = col_rename_dict,
+#     num_quantile = .x[[3]]
+#   ),
+#   .options = furrr_options(seed = TRUE, stdout = FALSE),
+#   .progress = FALSE
+# ) %>%
+#   write_parquet(paths$output$performance_quantile_test$local)
+#
+#
+# ## 4.2. Assessment Set ---------------------------------------------------------
+#
+# # Only value the assessment set for full runs
+# if (run_type == "full") {
+#   # Do the same thing for the assessment set. This will have accurate property
+#   # counts and proportions, since it also includes unsold properties
+#   message("Calculating assessment set aggregate statistics")
+#   future_map_dfr(
+#     geographies_list,
+#     ~ gen_agg_stats(
+#       data = assessment_data_pin,
+#       truth = sale_ratio_study_price,
+#       estimate = pred_pin_final_fmv_round,
+#       bldg_sqft = char_total_bldg_sf,
+#       rsn_col = prior_near_tot,
+#       rsf_col = prior_far_tot,
+#       triad = meta_triad_code,
+#       geography = !!.x[[1]],
+#       class = !!.x[[2]],
+#       col_dict = col_rename_dict
+#     ),
+#     .options = furrr_options(seed = TRUE, stdout = FALSE),
+#     .progress = FALSE
+#   ) %>%
+#     write_parquet(paths$output$performance_assessment$local)
+#
+#   # Same as above, but calculate stats per quantile of sale price
+#   message("Calculating assessment set quantile statistics")
+#   future_map_dfr(
+#     geographies_list_quantile,
+#     ~ gen_agg_stats_quantile(
+#       data = assessment_data_pin,
+#       truth = sale_ratio_study_price,
+#       estimate = pred_pin_final_fmv_round,
+#       rsn_col = prior_near_tot,
+#       rsf_col = prior_far_tot,
+#       triad = meta_triad_code,
+#       geography = !!.x[[1]],
+#       class = !!.x[[2]],
+#       col_dict = col_rename_dict,
+#       num_quantile = .x[[3]]
+#     ),
+#     .options = furrr_options(seed = TRUE, stdout = FALSE),
+#     .progress = FALSE
+#   ) %>%
+#     write_parquet(paths$output$performance_quantile_assessment$local)
+# }
+#
+# # End the stage timer and write the time elapsed to a temporary file
+# tictoc::toc(log = TRUE)
+# bind_rows(tictoc::tic.log(format = FALSE)) %>%
+#   arrow::write_parquet(gsub("//*", "/", file.path(
+#     paths$intermediate$timing$local,
+#     "model_timing_evaluate.parquet"
+#   )))

--- a/pipeline/03-evaluate.R
+++ b/pipeline/03-evaluate.R
@@ -12,23 +12,6 @@ tictoc::tic("Evaluate")
 # Load libraries, helpers, and recipes from files
 purrr::walk(list.files("R/", "\\.R$", full.names = TRUE), source)
 
-# Renaming dictionary for input columns. We want the actual value of the column
-# to become geography_id and the NAME of the column to become geography_name
-col_rename_dict <- c(
-  "triad_code" = "meta_triad_code",
-  "class" = "meta_class",
-  "geography_id" = "meta_township_code",
-  "geography_id" = "meta_township_name",
-  "geography_id" = "meta_nbhd_code",
-  "geography_id" = "loc_cook_municipality_name",
-  "geography_id" = "loc_ward_num",
-  "geography_id" = "loc_census_puma_geoid",
-  "geography_id" = "loc_census_tract_geoid",
-  "geography_id" = "loc_school_elementary_district_geoid",
-  "geography_id" = "loc_school_secondary_district_geoid",
-  "geography_id" = "loc_school_unified_district_geoid"
-)
-
 # Get the triad of the run to use for filtering
 run_triad <- tools::toTitleCase(params$assessment$triad)
 run_triad_code <- ccao::town_dict %>%
@@ -36,6 +19,12 @@ run_triad_code <- ccao::town_dict %>%
   distinct(triad_code) %>%
   pull(triad_code)
 
+# Load geometry name dictionary and columns to use for renaming
+geography_dict <- ccao::vars_dict %>%
+  filter(var_name_model %in% params$ratio_study$geographies)
+geography_cols <- geography_dict %>%
+  distinct(var_name_athena) %>%
+  pull()
 
 
 
@@ -47,7 +36,34 @@ message("Loading evaluation data")
 # Load the test results from the end of the train stage. This will be the most
 # recent 10% of sales and already includes predictions. This data will NOT
 # include multicard sales, so the unit of observation is PINs (1 PIN per row)
-test_data_card <- read_parquet(paths$output$test_card$local)
+test_data_card <- setDT(read_parquet(paths$output$test_card$local)) %>%
+  ccao::vars_rename(
+    names_from = "model",
+    names_to = "athena",
+    dict = geography_dict
+  )
+
+# Pivot the test data from wide to long format, such that there is a sale and
+# estimate for each geography specified by the geographies parameter
+test_data_long <- melt(
+  test_data_card,
+  id.vars = c("meta_pin", "meta_card_num", "meta_sale_document_num"),
+  measure.vars = geography_cols,
+  variable.name = "geography_type",
+  value.name = "geography_id"
+)[
+  test_data_card,
+  `:=`(
+    meta_sale_price = i.meta_sale_price,
+    pred_pin_final_fmv_round = i.pred_card_initial_fmv,
+    char_bldg_sf = i.char_bldg_sf,
+    prior_near_tot = i.prior_near_tot,
+    prior_far_tot = i.prior_far_tot,
+    triad_code = i.meta_triad_code,
+    class = i.meta_class
+  ),
+  on = c("meta_pin", "meta_card_num", "meta_sale_document_num")
+][!is.na(meta_sale_price), ]
 
 # Load the assessment results from the previous stage. This will include every
 # residential PIN that needs a value. It WILL include multicard properties
@@ -56,13 +72,36 @@ if (run_type == "full") {
   assessment_data_pin <- read_parquet(paths$output$assessment_pin$local) %>%
     filter(meta_triad_code == run_triad_code) %>%
     select(
-      meta_pin, meta_class, meta_triad_code, meta_township_code, meta_nbhd_code,
-      loc_cook_municipality_name, loc_ward_num, loc_census_puma_geoid,
-      loc_census_tract_geoid, loc_school_elementary_district_geoid,
-      loc_school_secondary_district_geoid, loc_school_unified_district_geoid,
-      char_total_bldg_sf, prior_far_tot, prior_near_tot,
-      pred_pin_final_fmv_round, sale_ratio_study_price
-    )
+      meta_pin, meta_class, meta_triad_code, char_total_bldg_sf, prior_far_tot,
+      prior_near_tot, pred_pin_final_fmv_round, sale_ratio_study_price,
+      all_of(params$ratio_study$geographies)
+    ) %>%
+    ccao::vars_rename(
+      names_from = "model",
+      names_to = "athena",
+      dict = geography_dict
+    ) %>%
+    setDT()
+
+  assessment_data_long <- melt(
+    assessment_data_pin,
+    id.vars = "meta_pin",
+    measure.vars = geography_cols,
+    variable.name = "geography_type",
+    value.name = "geography_id"
+  )[
+    assessment_data_pin,
+    `:=`(
+      meta_sale_price = i.sale_ratio_study_price,
+      pred_pin_final_fmv_round = i.pred_pin_final_fmv_round,
+      char_bldg_sf = i.char_total_bldg_sf,
+      prior_near_tot = i.prior_near_tot,
+      prior_far_tot = i.prior_far_tot,
+      triad_code = i.meta_triad_code,
+      class = i.meta_class
+    ),
+    on = "meta_pin"
+  ][!is.na(meta_sale_price), ]
 }
 
 
@@ -75,24 +114,27 @@ if (run_type == "full") {
 # Function to take either test set results or assessment results and generate
 # aggregate performance statistics for different levels of geography
 gen_agg_stats <- function(data, truth, estimate, bldg_sqft,
-                          rsn_col, rsf_col, triad, geography, class, col_dict) {
-  # List of column names that summary stat functions expand to
+                          rsn_col, rsf_col, groups, stage) {
+  # Fill for summary stats without enough sales to generate an output
+  rs_fill <- list(NA_real_, c(NA_real_, NA_real_), NA, NA, NA_real_)
+
+  # List of columns that summary stat functions expand to (from nested list)
   rs_cols <- sapply(
     c("cod", "prd", "prb"),
     \(x) paste0(x, "_", c("ci_2_5", "ci_97_5", "met", "ci_met", "n")),
     simplify = FALSE
   )
 
-  # List of summary stat/performance functions applied within summarize() below
+  # List of summary stat/performance functions applied within function below
   # Each function is on the right while the name of the function is on the left
   rs_fns_list <- list(
     # nolint start
-    cod_no_sop = \(x, y) ifelse(sum(!is.na(y)) > 1, cod(x / y, na.rm = TRUE), NA),
-    prd_no_sop = \(x, y) ifelse(sum(!is.na(y)) > 1, prd(x, y, na.rm = TRUE), NA),
-    prb_no_sop = \(x, y) ifelse(sum(!is.na(y)) > 1, prb(x, y, na.rm = TRUE), NA),
-    cod = \(x, y) ifelse(sum(!is.na(y)) > 33, list(ccao_cod(x / y, na.rm = TRUE)), NA),
-    prd = \(x, y) ifelse(sum(!is.na(y)) > 33, list(ccao_prd(x, y, na.rm = TRUE)), NA),
-    prb = \(x, y) ifelse(sum(!is.na(y)) > 33, list(ccao_prb(x, y, na.rm = TRUE)), NA)
+    cod_no_sop = \(x, y) ifelse(sum(!is.na(y)) > 1, cod(x / y, na.rm = TRUE), NA_real_),
+    prd_no_sop = \(x, y) ifelse(sum(!is.na(y)) > 1, prd(x, y, na.rm = TRUE), NA_real_),
+    prb_no_sop = \(x, y) ifelse(sum(!is.na(y)) > 1, prb(x, y, na.rm = TRUE), NA_real_),
+    cod = \(x, y) ifelse(sum(!is.na(y)) > 33, list(ccao_cod(x / y, na.rm = TRUE)), list(rs_fill)),
+    prd = \(x, y) ifelse(sum(!is.na(y)) > 33, list(ccao_prd(x, y, na.rm = TRUE)), list(rs_fill)),
+    prb = \(x, y) ifelse(sum(!is.na(y)) > 33, list(ccao_prb(x, y, na.rm = TRUE)), list(rs_fill))
     # nolint end
   )
   ys_fns_list <- list(
@@ -124,7 +166,7 @@ gen_agg_stats <- function(data, truth, estimate, bldg_sqft,
     max         = \(x, y) max((x - y) / y, na.rm = TRUE)
   )
 
-  # Generate aggregate performance stats by geography
+  # Generate aggregate performance stats by group
   df_stat <- as.data.table(data)[
     ,
     # Aggregate to get counts by geography without class
@@ -132,7 +174,7 @@ gen_agg_stats <- function(data, truth, estimate, bldg_sqft,
       num_pin_no_class = .N,
       num_sale_no_class = sum(!is.na(get(truth)))
     ),
-    by = c(triad, geography)
+    by = eval(groups[groups != "class"])
   ][
     ,
     {
@@ -154,7 +196,7 @@ gen_agg_stats <- function(data, truth, estimate, bldg_sqft,
         prior_near_total_av = sum(get(rsn_col) / 10, na.rm = TRUE),
         estimate_total_av = sum(get(estimate) / 10, na.rm = TRUE),
 
-        # Assessment-specific statistics
+        # Assessment-specific statistics such as ratio stats
         imap(rs_fns_list, ~ exec(.x, get(estimate), get(truth))),
         median_ratio = median(get(estimate) / get(truth), na.rm = TRUE),
 
@@ -191,11 +233,10 @@ gen_agg_stats <- function(data, truth, estimate, bldg_sqft,
           purrr::set_names(paste0("estimate_fmv_per_sqft_", names(.)))
       ))
     },
-    by = c(triad, geography, class)
+    by = eval(groups)
   ][
     ,
-      # COD, PRD, and PRB all output to a list. We can unnest each list to get
-      # additional info for each stat (95% CI, sample count, etc)
+      # Unnest ratio stat results from list to separate columns
       c("cod", rs_cols$cod, "prd", rs_cols$prd, "prb", rs_cols$prb) :=
       c(data.table::transpose(lapply(cod, \(x) unlist(x))),
         data.table::transpose(lapply(prd, \(x) unlist(x))),
@@ -203,44 +244,21 @@ gen_agg_stats <- function(data, truth, estimate, bldg_sqft,
       )
   ]
 
-  # Clean up the stats output (rename and relocate cols, replace inf values)
-  df_stat[
-    ,
-    `:=`(
-      by_class = !is.null(class),
-      geography_type = ifelse(
-        !is.null(geography),
-        ccao::vars_rename(
-          geography,
-          names_from = "model",
-          names_to = "athena"
-        ),
-        "triad_code"
-      )
-    )
-  ]
-
-  # Move important columns to front and rename geography column
-  setnames(df_stat, col_dict, names(col_dict), skip_absent = TRUE)
+  # Include the class column and an indicator for whether it was used
+  grp_by_class = "class" %in% groups
+  df_stat[, by_class := grp_by_class]
   setcolorder(df_stat, c(
-    "triad_code", "geography_type", "geography_id", "by_class",
-    names(col_dict)[col_dict == class]
+    groups[groups != "class"], "by_class", if (grp_by_class) "class" else NULL
   ))
 
   # Move ratio stat expanded columns to after their respective summary stat
-  move_after <- function(x, neworder = NULL, after = NULL) {
-    neworder <- data.table:::colnamesInt(x, neworder, check_dups=FALSE)
-    neworder <- c(setdiff(seq_len(data.table:::colnamesInt(x, after)), neworder), neworder) # nolint
-    neworder <- c(neworder, setdiff(seq_along(x), neworder))
-    setcolorder(x, neworder)
-  }
-  for (col in c("cod", "prd", "prb")) move_after(df_stat, rs_cols[[col]], col)
+  for (x in c("cod", "prd", "prb")) dt_move_after(df_stat, rs_cols[[x]], x)
 
-  # Convert columns to expected types
+  # Convert columns to expected types (i.e. _met columns should be logical)
   met_cols <- grep(names(df_stat), pattern = "_met$", value = TRUE)
   df_stat[ , (met_cols) := lapply(.SD, as.logical), .SDcols = met_cols]
 
-  # Replace infinite values with NA
+  # Replace infinite and NaN values with NA
   inf_cols <- names(df_stat)[!(
     grepl(names(df_stat), pattern = "_max$") &
     grepl(names(df_stat), pattern = "_yoy")) &
@@ -251,58 +269,13 @@ gen_agg_stats <- function(data, truth, estimate, bldg_sqft,
     (inf_cols) := lapply(.SD, \(x) replace(x, !is.finite(x), NA)),
     .SDcols = inf_cols
   ]
+
+  # Add the run stage so we can parition the collected results by filename
+  df_stat[, stage := stage]
   return(df_stat)
 }
 
-tic()
-meta_township_code <- gen_agg_stats(
-  data = assessment_data_pin,
-  truth = "sale_ratio_study_price",
-  estimate = "pred_pin_final_fmv_round",
-  bldg_sqft = "char_total_bldg_sf",
-  rsn_col = "prior_near_tot",
-  rsf_col = "prior_far_tot",
-  triad = "meta_triad_code",
-  geography = "meta_township_code",
-  class = NULL,
-  col_dict = col_rename_dict
-)
-toc()
 
-ids <- c(
-  "meta_township_code",
-  "meta_nbhd_code", "loc_cook_municipality_name",
-  "loc_ward_num", "loc_census_puma_geoid", "loc_census_tract_geoid",
-  "loc_school_elementary_district_geoid", "loc_school_secondary_district_geoid",
-  "loc_school_unified_district_geoid"
-)
-
-
-assessment_data <- as.data.table(assessment_data_pin)
-
-temp <- melt(
-  assessment_data,
-  id.vars = c("meta_pin"),
-  measure.vars = ids,
-  variable.name = "geography_type",
-  value.name = "geography_id"
-)[
-  assessment_data,
-  `:=`(
-    truth = i.sale_ratio_study_price,
-    estimate = i.pred_pin_final_fmv_round,
-    bldg_sqft = i.char_total_bldg_sf,
-    rsn_col = i.prior_near_tot,
-    rsf_col = i.prior_far_tot,
-    triad = i.meta_triad_code
-  ),
-  on = "meta_pin"
-]
-
-
-
-#
-#
 # # Same as the gen_agg_stats function, but with different statistics and broken
 # # out by quantile
 # gen_agg_stats_quantile <- function(data, truth, estimate,
@@ -360,135 +333,76 @@ temp <- melt(
 #       ~ replace(.x, !is.finite(.x), NA)
 #     ))
 # }
-#
-#
-#
-#
-# #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-# # 4. Generate Stats ------------------------------------------------------------
-# #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-#
-# # Use fancy tidyeval to create a list of all the geography levels with a
-# # class or no class option for each level
-# geographies_quosures <- rlang::quos(
-#   meta_township_code,
-#   meta_nbhd_code, loc_cook_municipality_name,
-#   loc_ward_num, loc_census_puma_geoid, loc_census_tract_geoid,
-#   loc_school_elementary_district_geoid, loc_school_secondary_district_geoid,
-#   loc_school_unified_district_geoid,
-#   NULL
-# )
-# geographies_list <- purrr::cross2(
-#   geographies_quosures,
-#   rlang::quos(meta_class, NULL)
-# )
-#
-# # Same as above, but add quantile breakouts to the grid expansion
-# geographies_list_quantile <- purrr::cross3(
-#   geographies_quosures,
-#   rlang::quos(meta_class, NULL),
-#   params$ratio_study$num_quantile
-# )
-#
-#
-# ## 4.1. Test Set ---------------------------------------------------------------
-#
-# # Use parallel map to calculate aggregate stats for every geography level and
-# # class combination for the test set
-# message("Calculating test set aggregate statistics")
-# future_map_dfr(
-#   geographies_list,
-#   ~ gen_agg_stats(
-#     data = test_data_card,
-#     truth = meta_sale_price,
-#     estimate = pred_card_initial_fmv,
-#     bldg_sqft = char_bldg_sf,
-#     rsn_col = prior_near_tot,
-#     rsf_col = prior_far_tot,
-#     triad = meta_triad_code,
-#     geography = !!.x[[1]],
-#     class = !!.x[[2]],
-#     col_dict = col_rename_dict
-#   ),
-#   .options = furrr_options(seed = TRUE, stdout = FALSE),
-#   .progress = FALSE
-# ) %>%
-#   write_parquet(paths$output$performance_test$local)
-#
-# # Same as above, but calculate stats per quantile of sale price
-# message("Calculating test set quantile statistics")
-# future_map_dfr(
-#   geographies_list_quantile,
-#   ~ gen_agg_stats_quantile(
-#     data = test_data_card,
-#     truth = meta_sale_price,
-#     estimate = pred_card_initial_fmv,
-#     rsn_col = prior_near_tot,
-#     rsf_col = prior_far_tot,
-#     triad = meta_triad_code,
-#     geography = !!.x[[1]],
-#     class = !!.x[[2]],
-#     col_dict = col_rename_dict,
-#     num_quantile = .x[[3]]
-#   ),
-#   .options = furrr_options(seed = TRUE, stdout = FALSE),
-#   .progress = FALSE
-# ) %>%
-#   write_parquet(paths$output$performance_quantile_test$local)
-#
-#
-# ## 4.2. Assessment Set ---------------------------------------------------------
-#
-# # Only value the assessment set for full runs
-# if (run_type == "full") {
-#   # Do the same thing for the assessment set. This will have accurate property
-#   # counts and proportions, since it also includes unsold properties
-#   message("Calculating assessment set aggregate statistics")
-#   future_map_dfr(
-#     geographies_list,
-#     ~ gen_agg_stats(
-#       data = assessment_data_pin,
-#       truth = sale_ratio_study_price,
-#       estimate = pred_pin_final_fmv_round,
-#       bldg_sqft = char_total_bldg_sf,
-#       rsn_col = prior_near_tot,
-#       rsf_col = prior_far_tot,
-#       triad = meta_triad_code,
-#       geography = !!.x[[1]],
-#       class = !!.x[[2]],
-#       col_dict = col_rename_dict
-#     ),
-#     .options = furrr_options(seed = TRUE, stdout = FALSE),
-#     .progress = FALSE
-#   ) %>%
-#     write_parquet(paths$output$performance_assessment$local)
-#
-#   # Same as above, but calculate stats per quantile of sale price
-#   message("Calculating assessment set quantile statistics")
-#   future_map_dfr(
-#     geographies_list_quantile,
-#     ~ gen_agg_stats_quantile(
-#       data = assessment_data_pin,
-#       truth = sale_ratio_study_price,
-#       estimate = pred_pin_final_fmv_round,
-#       rsn_col = prior_near_tot,
-#       rsf_col = prior_far_tot,
-#       triad = meta_triad_code,
-#       geography = !!.x[[1]],
-#       class = !!.x[[2]],
-#       col_dict = col_rename_dict,
-#       num_quantile = .x[[3]]
-#     ),
-#     .options = furrr_options(seed = TRUE, stdout = FALSE),
-#     .progress = FALSE
-#   ) %>%
-#     write_parquet(paths$output$performance_quantile_assessment$local)
-# }
-#
-# # End the stage timer and write the time elapsed to a temporary file
-# tictoc::toc(log = TRUE)
-# bind_rows(tictoc::tic.log(format = FALSE)) %>%
-#   arrow::write_parquet(gsub("//*", "/", file.path(
-#     paths$intermediate$timing$local,
-#     "model_timing_evaluate.parquet"
-#   )))
+
+
+
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# 4. Generate Stats ------------------------------------------------------------
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+# Enable parallel backend for generating stats more quickly
+plan(multisession, workers = num_threads / 2)
+
+# Create a list of the data and class combinations to iterate over
+map_list <- list(
+  data = list(rep(test_data_long, 2), rep(assessment_data_long, 2)),
+  class = list("class", NULL, "class", NULL),
+  stage = list(rep("test", 2), rep("assessment", 2))
+)
+
+## 4.1. Performance ------------------------------------------------------------
+
+# Use parallel map to calculate aggregate stats for every geography level and
+# class combination for both the test and assessment set
+message("Calculating aggregate performance statistics")
+tic()
+performance <- future_pmap(
+  map_list,
+  function(data, class, stage) {
+    gen_agg_stats(
+      data = data,
+      truth = "meta_sale_price",
+      estimate = "pred_pin_final_fmv_round",
+      bldg_sqft = "char_bldg_sf",
+      rsn_col = "prior_near_tot",
+      rsf_col = "prior_far_tot",
+      groups = c("triad_code", "geography_type", "geography_id", class),
+      stage = stage
+    )
+  },
+  .options = furrr_options(seed = TRUE, stdout = FALSE),
+  .progress = FALSE
+)
+toc()
+
+
+## 4.2. Performance Quantile ---------------------------------------------------
+
+# Same as above, but calculate stats per quantile of sale price
+message("Calculating assessment set quantile statistics")
+future_map_dfr(
+  geographies_list_quantile,
+  ~ gen_agg_stats_quantile(
+    data = assessment_data_pin,
+    truth = sale_ratio_study_price,
+    estimate = pred_pin_final_fmv_round,
+    rsn_col = prior_near_tot,
+    rsf_col = prior_far_tot,
+    triad = meta_triad_code,
+    geography = !!.x[[1]],
+    class = !!.x[[2]],
+    col_dict = col_rename_dict,
+    num_quantile = .x[[3]]
+  ),
+  .options = furrr_options(seed = TRUE, stdout = FALSE),
+  .progress = FALSE
+) %>%
+  write_parquet(paths$output$performance_quantile_assessment$local)
+
+# End the stage timer and write the time elapsed to a temporary file
+tictoc::toc(log = TRUE)
+bind_rows(tictoc::tic.log(format = FALSE)) %>%
+  arrow::write_parquet(gsub("//*", "/", file.path(
+    paths$intermediate$timing$local,
+    "model_timing_evaluate.parquet"
+  )))

--- a/pipeline/05-finalize.R
+++ b/pipeline/05-finalize.R
@@ -127,8 +127,10 @@ metadata <- tibble::tibble(
 
 
 #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-# 3. Generate performance report -----------------------------------------------
+# 3. Generate Reports ----------------------------------------------------------
 #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+## 3.1. Performance Report -----------------------------------------------------
 
 # Wrap this block in an error handler so that the pipeline continues execution
 # even if report generation fails. This is important because the report file is


### PR DESCRIPTION
This PR swaps the `dplyr` code in the `assess` and `evaluate` stages of the model with native `data.table` code.

- Code for grabbing two sales was wrong is limited cases
- Bad char flag busted
- `assess` reduce from 1100s to 430s to 210s
- `evaluate` 720s