### PR TITLE
Add non-SOP MKI to `evaluate` stage

### DIFF
--- a/pipeline/03-evaluate.R
+++ b/pipeline/03-evaluate.R
@@ -86,6 +86,7 @@ gen_agg_stats <- function(data, truth, estimate, bldg_sqft,
     cod_no_sop = ~ ifelse(sum(!is.na(.y)) > 1, cod(.x / .y, na.rm = TRUE), NA),
     prd_no_sop = ~ ifelse(sum(!is.na(.y)) > 1, prd(.x, .y, na.rm = TRUE), NA),
     prb_no_sop = ~ ifelse(sum(!is.na(.y)) > 1, prb(.x, .y, na.rm = TRUE), NA),
+    mki_no_sop = ~ ifelse(sum(!is.na(.y)) > 1, mki(.x, .y, na.rm = TRUE), NA),
     cod = ~ ifelse(
       sum(!is.na(.y)) > 33,
       list(ccao_cod(.x / .y, na.rm = TRUE)),


### PR DESCRIPTION
This PR adds [MKI](https://ccao-data.github.io/assessr/reference/index.html#-modified-kakwani-index-mki-) to the `evaluate` stage of the modelling pipeline and subsequent output.