### PR TITLE
Add working/partition year for upload

### DIFF
--- a/dvc.yaml
+++ b/dvc.yaml
@@ -49,6 +49,7 @@ stages:
         cache: false
     - output/workflow/recipe/model_workflow_recipe.rds:
         cache: false
+
   assess:
     cmd: Rscript pipeline/02-assess.R
     desc: >

--- a/params.yaml
+++ b/params.yaml
@@ -33,19 +33,23 @@ toggle:
 
 # Assessment context and dates
 assessment:
-  # Year of assessment. Used to partition results and pull data
+  # Year of assessment. Used to pull land rates, HIEs, and other information
   year: "2023"
 
   # The statutorily set "sale date" for the purpose of prediction
   date: "2023-01-01"
 
-  # Added context for model artifacts stored in s3. Does not change behavior
+  # Added context for model artifacts stored in S3. Does not change behavior
   triad: "south"
   group: "residential"
 
   # Year from which property characteristics are pulled. Usually lags the
   # assessment year by 1
   data_year: "2022"
+
+  # Year used to partition data on S3. Working year in this case means the year
+  # the Data Department is currently creating models for
+  working_year: "2024"
 
 # Parameters used to define the input/training data
 input:

--- a/pipeline/06-upload.R
+++ b/pipeline/06-upload.R
@@ -11,10 +11,8 @@
 # Load libraries, helpers, and recipes from files
 purrr::walk(list.files("R/", "\\.R$", full.names = TRUE), source)
 
-# Load various overridden parameters as defined in the `finalize` step
+# Load various parameters as defined in the `finalize` step
 metadata <- read_parquet(paths$output$metadata$local)
-cv_enable <- metadata$cv_enable
-shap_enable <- metadata$shap_enable
 run_id <- metadata$run_id
 
 
@@ -30,7 +28,7 @@ if (upload_enable) {
   # Initialize a dictionary of paths AND S3 URIs specific to the run ID and year
   paths <- model_file_dict(
     run_id = run_id,
-    year = params$assessment$year
+    year = params$assessment$upload_year
   )
 
 
@@ -126,7 +124,7 @@ if (upload_enable) {
   # reduce file size and improve query performance we partition them by year,
   # run ID, and township
   read_parquet(paths$output$assessment_card$local) %>%
-    mutate(run_id = run_id, year = params$assessment$year) %>%
+    mutate(run_id = run_id, year = params$assessment$upload_year) %>%
     group_by(year, run_id, township_code) %>%
     arrow::write_dataset(
       path = paths$output$assessment_card$s3,
@@ -135,7 +133,7 @@ if (upload_enable) {
       compression = "snappy"
     )
   read_parquet(paths$output$assessment_pin$local) %>%
-    mutate(run_id = run_id, year = params$assessment$year) %>%
+    mutate(run_id = run_id, year = params$assessment$upload_year) %>%
     group_by(year, run_id, township_code) %>%
     arrow::write_dataset(
       path = paths$output$assessment_pin$s3,
@@ -179,7 +177,7 @@ if (upload_enable) {
   if (shap_enable) {
     message("Uploading SHAP values")
     read_parquet(paths$output$shap$local) %>%
-      mutate(run_id = run_id, year = params$assessment$year) %>%
+      mutate(run_id = run_id, year = params$assessment$upload_year) %>%
       group_by(year, run_id, township_code) %>%
       arrow::write_dataset(
         path = paths$output$shap$s3,

--- a/pipeline/06-upload.R
+++ b/pipeline/06-upload.R
@@ -28,7 +28,7 @@ if (upload_enable) {
   # Initialize a dictionary of paths AND S3 URIs specific to the run ID and year
   paths <- model_file_dict(
     run_id = run_id,
-    year = params$assessment$upload_year
+    year = params$assessment$working_year
   )
 
 
@@ -124,7 +124,7 @@ if (upload_enable) {
   # reduce file size and improve query performance we partition them by year,
   # run ID, and township
   read_parquet(paths$output$assessment_card$local) %>%
-    mutate(run_id = run_id, year = params$assessment$upload_year) %>%
+    mutate(run_id = run_id, year = params$assessment$working_year) %>%
     group_by(year, run_id, township_code) %>%
     arrow::write_dataset(
       path = paths$output$assessment_card$s3,
@@ -133,7 +133,7 @@ if (upload_enable) {
       compression = "snappy"
     )
   read_parquet(paths$output$assessment_pin$local) %>%
-    mutate(run_id = run_id, year = params$assessment$upload_year) %>%
+    mutate(run_id = run_id, year = params$assessment$working_year) %>%
     group_by(year, run_id, township_code) %>%
     arrow::write_dataset(
       path = paths$output$assessment_pin$s3,
@@ -177,7 +177,7 @@ if (upload_enable) {
   if (shap_enable) {
     message("Uploading SHAP values")
     read_parquet(paths$output$shap$local) %>%
-      mutate(run_id = run_id, year = params$assessment$upload_year) %>%
+      mutate(run_id = run_id, year = params$assessment$working_year) %>%
       group_by(year, run_id, township_code) %>%
       arrow::write_dataset(
         path = paths$output$shap$s3,


### PR DESCRIPTION
This PR adds a separate `working_year` parameter to `params.yaml`. The purpose of this variable is to allow us to partition runs for future assessment years into the appropriate S3 partitions, even when the data for that year is not yet available.

For example, we're currently working on the 2024 residential model, but do not yet have all 2024 data available. As a result, we're using 2023 data for model testing and development. This results in current runs populating the `year=2023` partitions in S3 (last years assessment year).
