### PR TITLE
Add environmental variable inputs/overrides passed via workflow dispatch

### DIFF
--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -13,6 +13,16 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, closed]
   workflow_dispatch:
+    inputs:
+      enable_upload:
+        type: boolean
+        description: Upload results to S3
+        default: false
+        required: true
+      run_note:
+        type: string
+        description: Note to include with run
+        required: true
   push:
     branches: [master]
 
@@ -37,3 +47,5 @@ jobs:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
       CONTAINER_ENV_VARS: |
         AWS_SNS_ARN_MODEL_STATUS=${{ secrets.AWS_SNS_ARN_MODEL_STATUS }}
+        UPLOAD_ENABLE_OVERRIDE=${{ inputs.enable_upload }}
+        WORKFLOW_RUN_NOTE=${{ inputs.run_note }}

--- a/README.Rmd
+++ b/README.Rmd
@@ -690,12 +690,11 @@ If you have write permissions for this repository (i.e. you are a member of the 
 
 #### Initialization
 
-Model runs are initiated by the [`build-and-run-model`](./.github/workflows/build-and-run-model.yaml) workflow when one of the following events is triggered:
+Model runs are initiated by the [`build-and-run-model`](./.github/workflows/build-and-run-model.yaml) workflow via [manual dispatch](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow).
 
-* A pull request is opened, or a commit is pushed to an open pull request
-* The workflow is [manually dispatched](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow)
+To run a model, use the **Run workflow** button on right side of the `build-and-run-model` [Actions page](https://github.com/ccao-data/model-res-avm/actions/workflows/build-and-run-model.yaml).
 
-In both cases, runs are gated behind a [deploy environment](https://docs.github.com/en/enterprise-cloud@latest/actions/deployment/targeting-different-environments/using-environments-for-deployment) that requires approval from a `@ccao-data/core-team` member before the model will run. The `build` job to rebuild a Docker image for the model will always run, but the subsequent `run` job will not run unless a core-team member approves it.
+Runs are gated behind a [deploy environment](https://docs.github.com/en/enterprise-cloud@latest/actions/deployment/targeting-different-environments/using-environments-for-deployment) that requires approval from a `@ccao-data/core-team` member before the model will run. The `build` job to rebuild a Docker image for the model will always run, but the subsequent `run` job will not run unless a core-team member approves it.
 
 #### Monitoring
 

--- a/README.md
+++ b/README.md
@@ -1159,14 +1159,14 @@ Batch using GitHub Actions workflow runs.
 
 Model runs are initiated by the
 [`build-and-run-model`](./.github/workflows/build-and-run-model.yaml)
-workflow when one of the following events is triggered:
+workflow via [manual
+dispatch](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow).
 
-- A pull request is opened, or a commit is pushed to an open pull
-  request
-- The workflow is [manually
-  dispatched](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow)
+To run a model, use the **Run workflow** button on right side of the
+`build-and-run-model` [Actions
+page](https://github.com/ccao-data/model-res-avm/actions/workflows/build-and-run-model.yaml).
 
-In both cases, runs are gated behind a [deploy
+Runs are gated behind a [deploy
 environment](https://docs.github.com/en/enterprise-cloud@latest/actions/deployment/targeting-different-environments/using-environments-for-deployment)
 that requires approval from a `@ccao-data/core-team` member before the
 model will run. The `build` job to rebuild a Docker image for the model

--- a/pipeline/05-finalize.R
+++ b/pipeline/05-finalize.R
@@ -32,8 +32,11 @@ run_end_timestamp <- lubridate::now()
 # Get the commit of the current reference
 git_commit <- git2r::revparse_single(git2r::repository(), "HEAD")
 
-# Use the run note included in params.yaml as the note
-run_note <- params$run_note
+# If in a CI context, use the run note passed to the workflow. Otherwise, use
+# the note included in params.yaml
+run_note <- as.logical(
+  Sys.getenv("WORKFLOW_RUN_NOTE", unset = params$run_note)
+)
 
 
 ## 2.2. DVC Hashes -------------------------------------------------------------


### PR DESCRIPTION
This PR gates model runs behind a manual workflow dispatch step in conjunction with https://github.com/ccao-data/actions/pull/10. It adds dispatch inputs asking the user whether or not they want to save the run results to S3 and what the run attached to the run should be.

The intention here is to be more intentional about which runs we dispatch to Batch and to cut down on the noise from deploy notifications.