### PR TITLE
Add package dependency note for dvc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1112,7 +1112,7 @@ following stages:
 The entire end-to-end pipeline can also be run using
 [DVC](https://dvc.org/). DVC will track the dependencies and parameters
 required to run each stage, cache intermediate files, and store
-versioned input data on S3. The packages `dvc` and `dvc_s3` are required
+versioned input data on S3. The packages `dvc` and `dvc[s3]` are required
 for the following commands.
 
 To pull all the necessary input data based on the information in

--- a/README.md
+++ b/README.md
@@ -1112,7 +1112,7 @@ following stages:
 The entire end-to-end pipeline can also be run using
 [DVC](https://dvc.org/). DVC will track the dependencies and parameters
 required to run each stage, cache intermediate files, and store
-versioned input data on S3.
+versioned input data on S3. Make sure to have `dvc` and `dvc_s3` installed.
 
 To pull all the necessary input data based on the information in
 `dvc.lock`, run:

--- a/README.md
+++ b/README.md
@@ -1112,7 +1112,8 @@ following stages:
 The entire end-to-end pipeline can also be run using
 [DVC](https://dvc.org/). DVC will track the dependencies and parameters
 required to run each stage, cache intermediate files, and store
-versioned input data on S3. Make sure to have `dvc` and `dvc_s3` installed.
+versioned input data on S3. The packages `dvc` and `dvc_s3` are required
+for the following commands.
 
 To pull all the necessary input data based on the information in
 `dvc.lock`, run:


### PR DESCRIPTION
Billy gave me the info on which dependencies are needed for `dvc` to work. I added a small snippet in the `README` so that the next time someone takes a look for dependencies they'll find `dvc` and `dvc_s3`.