### PR TITLE
Add check to make sure input and output data match upon model report generation

### DIFF
--- a/reports/_setup.qmd
+++ b/reports/_setup.qmd
@@ -75,7 +75,7 @@ if (metadata$run_id != params$run_id) {
 
 # Extract hash values from dvc.lock file
 dvc_lock_values <- sapply(
-  read_yaml(here::here("dvc.lock"))$stages$ingest$outs, 
+  read_yaml(here::here("dvc.lock"))$stages$ingest$outs,
   function(x) x$md5
 )
 

--- a/reports/_setup.qmd
+++ b/reports/_setup.qmd
@@ -82,7 +82,7 @@ dvc_lock_values <- sapply(
 metadata_dvc_md5 <- metadata %>%
   select(starts_with("dvc_md5"))
 
-# Compare each column value with the corresponding yaml value
+# Compare hash for each metadata value with the corresponding dvc.lock value
 comparison_results <- purrr::map2(metadata_dvc_md5, dvc_lock_values, ~ .x == .y)
 
 # Check if all hashes match between metadata and dvc.lock

--- a/reports/_setup.qmd
+++ b/reports/_setup.qmd
@@ -74,30 +74,15 @@ if (metadata$run_id != params$run_id) {
 }
 
 # Extract hash values from dvc.lock file
-dvc_lock <- read_yaml("../dvc.lock")
-dvc_lock_values <- c(
-  dvc_lock$stages$ingest$outs[[1]]$md5,
-  dvc_lock$stages$ingest$outs[[2]]$md5,
-  dvc_lock$stages$ingest$outs[[3]]$md5,
-  dvc_lock$stages$ingest$outs[[4]]$md5,
-  dvc_lock$stages$ingest$outs[[5]]$md5,
-  dvc_lock$stages$ingest$outs[[6]]$md5,
-  dvc_lock$stages$ingest$outs[[7]]$md5
-)
+dvc_lock_values <- sapply(
+  read_yaml(here::here("dvc.lock"))$stages$ingest$outs, 
+  function(x) x$md5)
 
 metadata_dvc_md5 <- metadata %>%
-  select(
-    dvc_md5_assessment_data,
-    dvc_md5_char_data,
-    dvc_md5_complex_id_data,
-    dvc_md5_hie_data,
-    dvc_md5_land_nbhd_rate_data,
-    dvc_md5_land_site_rate_data,
-    dvc_md5_training_data
-  )
+  select(starts_with("dvc_md5"))
 
 # Compare each column value with the corresponding yaml value
-comparison_results <- mapply(FUN = `==`, metadata_dvc_md5, dvc_lock_values)
+comparison_results <- purrr::map2(metadata_dvc_md5, dvc_lock_values, ~ .x == .y)
 
 # Check if all hashes match between metadata and dvc.lock
 if (!all(comparison_results)) {

--- a/reports/_setup.qmd
+++ b/reports/_setup.qmd
@@ -1,7 +1,7 @@
 ---
 params:
-  run_id: "2023-12-19-recursing-jacob"
-  year: "2023"
+  run_id: "2023-12-20-awesome-claire"
+  year: "2024"
 ---
 
 ```{r}
@@ -72,6 +72,43 @@ if (metadata$run_id != params$run_id) {
     "should run model_fetch_run() to fetch model outputs from S3"
   )
 }
+
+dvc_lock <- read_yaml("../dvc.lock")
+
+# Extract values from the dvc_lock object
+dvc_lock_values <- c(
+  dvc_lock$stages$ingest$outs[[1]]$md5, # assessment_data
+  dvc_lock$stages$ingest$outs[[2]]$md5, # char_data
+  dvc_lock$stages$ingest$outs[[3]]$md5, # complex_id_data
+  dvc_lock$stages$ingest$outs[[4]]$md5, # hie_data
+  dvc_lock$stages$ingest$outs[[5]]$md5, # land_nbhd_rate_data
+  dvc_lock$stages$ingest$outs[[6]]$md5, # land_site_rate_data
+  dvc_lock$stages$ingest$outs[[7]]$md5  # training_data
+)
+
+metadata_dvc_md5 <- metadata %>%
+  select(
+    dvc_md5_assessment_data,
+    dvc_md5_char_data,
+    dvc_md5_complex_id_data,
+    dvc_md5_hie_data,
+    dvc_md5_land_nbhd_rate_data,
+    dvc_md5_land_site_rate_data,
+    dvc_md5_training_data
+  )
+
+# Compare each column value with the corresponding yaml value
+comparison_results <- mapply(FUN = `==`, metadata_dvc_md5, dvc_lock_values)
+
+# Check if all hashes match
+if(!all(comparison_results)) {
+  stop(
+    "Hash values between the dvc.lock file and the metadata
+    do not match. Potential mismatch in input and output data."
+  )
+} 
+
+
 
 # Get the triad of the run to use for filtering
 run_triad <- tools::toTitleCase(metadata$assessment_triad)

--- a/reports/_setup.qmd
+++ b/reports/_setup.qmd
@@ -73,17 +73,16 @@ if (metadata$run_id != params$run_id) {
   )
 }
 
+# Extract hash values from dvc.lock file
 dvc_lock <- read_yaml("../dvc.lock")
-
-# Extract values from the dvc_lock object
 dvc_lock_values <- c(
-  dvc_lock$stages$ingest$outs[[1]]$md5, # assessment_data
-  dvc_lock$stages$ingest$outs[[2]]$md5, # char_data
-  dvc_lock$stages$ingest$outs[[3]]$md5, # complex_id_data
-  dvc_lock$stages$ingest$outs[[4]]$md5, # hie_data
-  dvc_lock$stages$ingest$outs[[5]]$md5, # land_nbhd_rate_data
-  dvc_lock$stages$ingest$outs[[6]]$md5, # land_site_rate_data
-  dvc_lock$stages$ingest$outs[[7]]$md5  # training_data
+  dvc_lock$stages$ingest$outs[[1]]$md5,
+  dvc_lock$stages$ingest$outs[[2]]$md5,
+  dvc_lock$stages$ingest$outs[[3]]$md5,
+  dvc_lock$stages$ingest$outs[[4]]$md5,
+  dvc_lock$stages$ingest$outs[[5]]$md5,
+  dvc_lock$stages$ingest$outs[[6]]$md5,
+  dvc_lock$stages$ingest$outs[[7]]$md5
 )
 
 metadata_dvc_md5 <- metadata %>%
@@ -100,15 +99,13 @@ metadata_dvc_md5 <- metadata %>%
 # Compare each column value with the corresponding yaml value
 comparison_results <- mapply(FUN = `==`, metadata_dvc_md5, dvc_lock_values)
 
-# Check if all hashes match
+# Check if all hashes match between metadata and dvc.lock
 if(!all(comparison_results)) {
   stop(
     "Hash values between the dvc.lock file and the metadata
     do not match. Potential mismatch in input and output data."
   )
 } 
-
-
 
 # Get the triad of the run to use for filtering
 run_triad <- tools::toTitleCase(metadata$assessment_triad)

--- a/reports/_setup.qmd
+++ b/reports/_setup.qmd
@@ -76,7 +76,8 @@ if (metadata$run_id != params$run_id) {
 # Extract hash values from dvc.lock file
 dvc_lock_values <- sapply(
   read_yaml(here::here("dvc.lock"))$stages$ingest$outs, 
-  function(x) x$md5)
+  function(x) x$md5
+)
 
 metadata_dvc_md5 <- metadata %>%
   select(starts_with("dvc_md5"))

--- a/reports/_setup.qmd
+++ b/reports/_setup.qmd
@@ -100,12 +100,12 @@ metadata_dvc_md5 <- metadata %>%
 comparison_results <- mapply(FUN = `==`, metadata_dvc_md5, dvc_lock_values)
 
 # Check if all hashes match between metadata and dvc.lock
-if(!all(comparison_results)) {
+if (!all(comparison_results)) {
   stop(
-    "Hash values between the dvc.lock file and the metadata
-    do not match. Potential mismatch in input and output data."
+    "Hash values between the dvc.lock file and the metadata",
+    "do not match. Potential mismatch in input and output data."
   )
-} 
+}
 
 # Get the triad of the run to use for filtering
 run_triad <- tools::toTitleCase(metadata$assessment_triad)

--- a/reports/_setup.qmd
+++ b/reports/_setup.qmd
@@ -1,7 +1,7 @@
 ---
 params:
-  run_id: "2023-12-20-awesome-claire"
-  year: "2024"
+  run_id: "2023-12-19-recursing-jacob"
+  year: "2023"
 ---
 
 ```{r}


### PR DESCRIPTION
Add check to make sure hashes match between metadata file and `dvc.lock` file so we can check that input and output data are from the same model run.

Closes #98.