### PR TITLE
Bump vCPUs used by Batch runner and switch to EC2 backend

### DIFF
--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -39,9 +39,12 @@ jobs:
       packages: write
     uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@main
     with:
-      vcpu: "16.0"
+      backend: "ec2"
+      vcpu: "32"
       memory: "65536"
-      role-duration-seconds: 14400  # Worst-case time for a full model run
+      # Maximum pipeline runtime. This is slightly below 6 hours, which
+      # is the maximum length of any single GitHub Actions job
+      role-duration-seconds: 21000
     secrets:
       AWS_IAM_ROLE_TO_ASSUME_ARN: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}


### PR DESCRIPTION
This PR bumps the vCPUs for each model run, switches our compute backend to EC2 instead of Fargate, and bumps the AWS token expiration timeout to just below 6 hours (the maximum runtime of a GitHub job).