### PR TITLE
Add map of townhome complex IDs

### DIFF
--- a/reports/_input.qmd
+++ b/reports/_input.qmd
@@ -283,7 +283,8 @@ assessment_pin %>%
 chars_data_1year <- chars_data %>%
   filter(meta_year == "2022")
 
-complex_id_data_v2 <- left_join(complex_id_data, chars_data_1year, by = "meta_pin")
+complex_id_data_v2 <- left_join(complex_id_data, chars_data_1year, by = "meta_pin") %>%
+  filter(meta_township_code.x == 35)
 
 colorPalette <- colorFactor(palette = "viridis", domain = complex_id_data_v2$meta_complex_id)
 

--- a/reports/_input.qmd
+++ b/reports/_input.qmd
@@ -282,22 +282,32 @@ assessment_pin %>%
 ## Map of Townhome Complex IDs
 
 ```{r _input_complex_id_map}
-chars_data_1year <- chars_data %>%
-  filter(meta_year == "2022")
+complex_id_map <- complex_id_data %>%
+  left_join(
+    chars_data %>%
+      filter(meta_year == "2022") %>%
+      select(meta_pin, loc_longitude, loc_latitude),
+    by = "meta_pin"
+  ) %>%
+  filter(meta_township_code == 35)
 
-complex_id_data_v2 <- left_join(complex_id_data, chars_data_1year, by = "meta_pin") %>%
-  filter(meta_township_code.x == 35)
+colorPalette <- colorspace::qualitative_hcl(
+  length(unique(complex_id_map$meta_complex_id)),
+  palette = "Dark 3"
+)
 
-colorPalette <- colorFactor(palette = "viridis", domain = complex_id_data_v2$meta_complex_id)
-
-leaflet(complex_id_data_v2) %>%
-  addTiles() %>%
+leaflet(complex_id_map) %>%
+  addProviderTiles(providers$CartoDB.Positron) %>%
   addCircleMarkers(
     ~loc_longitude,
     ~loc_latitude,
-    color = ~ colorPalette(meta_complex_id),
     popup = ~ as.character(meta_complex_id),
-    radius = 4
+    radius = 5,
+    weight = 1,
+    color = "darkgrey",
+    opacity = 1,
+    fillColor = colorPalette,
+    fillOpacity = 1
   )
 ```
 

--- a/reports/_input.qmd
+++ b/reports/_input.qmd
@@ -279,6 +279,8 @@ assessment_pin %>%
 
 :::
 
+## Map of Townhome Complex IDs
+
 ```{r _input_complex_id_map}
 chars_data_1year <- chars_data %>%
   filter(meta_year == "2022")

--- a/reports/_input.qmd
+++ b/reports/_input.qmd
@@ -279,30 +279,13 @@ assessment_pin %>%
 
 :::
 
-```{r}
-test1 <- char_data %>%
-  dplyr::filter(meta_year == "2022")
+```{r _input_complex_id_map}
+chars_data_1year <- chars_data %>%
+  filter(meta_year == "2022")
 
-complex_id_data_v2 <- left_join(complex_id_data, test1, by = "meta_pin") %>%
-  dplyr::filter(meta_township_code.x == 35)
-```
+complex_id_data_v2 <- left_join(complex_id_data, chars_data_1year, by = "meta_pin") %>%
+  filter(meta_township_code.x == 35)
 
-
-```{r}
-shapes <- c(15, 16, 17, 18, 19, 20)
-
-# Plotting with a limited set of shapes and a variety of colors
-ggplot(complex_id_data_v2, aes(x = loc_longitude, y = loc_latitude, color = as.factor(meta_complex_id), shape = as.factor(meta_complex_id %% 6))) +
-  geom_point(size = 3) +
-  scale_shape_manual(values = shapes) +
-  ggtitle("Map of Complexes by Latitude and Longitude") +
-  xlab("Longitude") +
-  ylab("Latitude") +
-  theme_minimal() +
-  theme(legend.position = "none") # Removes the legend
-
-```
-```{r}
 # Generating a color palette
 colorPalette <- colorFactor(palette = "viridis", domain = complex_id_data_v2$meta_complex_id)
 
@@ -317,4 +300,5 @@ leaflet(complex_id_data_v2) %>%
     radius = 4
   )
 ```
+
 

--- a/reports/_input.qmd
+++ b/reports/_input.qmd
@@ -295,8 +295,8 @@ leaflet(complex_id_data_v2) %>%
   addCircleMarkers(
     ~loc_longitude,
     ~loc_latitude,
-    color = ~colorPalette(meta_complex_id),
-    popup = ~as.character(meta_complex_id),
+    color = ~ colorPalette(meta_complex_id),
+    popup = ~ as.character(meta_complex_id),
     radius = 4
   )
 ```

--- a/reports/_input.qmd
+++ b/reports/_input.qmd
@@ -278,3 +278,43 @@ assessment_pin %>%
 ```
 
 :::
+
+```{r}
+test1 <- char_data %>%
+  dplyr::filter(meta_year == "2022")
+
+complex_id_data_v2 <- left_join(complex_id_data, test1, by = "meta_pin") %>%
+  dplyr::filter(meta_township_code.x == 35)
+```
+
+
+```{r}
+shapes <- c(15, 16, 17, 18, 19, 20)
+
+# Plotting with a limited set of shapes and a variety of colors
+ggplot(complex_id_data_v2, aes(x = loc_longitude, y = loc_latitude, color = as.factor(meta_complex_id), shape = as.factor(meta_complex_id %% 6))) +
+  geom_point(size = 3) +
+  scale_shape_manual(values = shapes) +
+  ggtitle("Map of Complexes by Latitude and Longitude") +
+  xlab("Longitude") +
+  ylab("Latitude") +
+  theme_minimal() +
+  theme(legend.position = "none") # Removes the legend
+
+```
+```{r}
+# Generating a color palette
+colorPalette <- colorFactor(palette = "viridis", domain = complex_id_data_v2$meta_complex_id)
+
+# Creating a leaflet map with colored markers
+leaflet(complex_id_data_v2) %>%
+  addTiles() %>%
+  addCircleMarkers(
+    ~loc_longitude,
+    ~loc_latitude,
+    color = ~colorPalette(meta_complex_id),
+    popup = ~as.character(meta_complex_id),
+    radius = 4
+  )
+```
+

--- a/reports/_input.qmd
+++ b/reports/_input.qmd
@@ -283,13 +283,10 @@ assessment_pin %>%
 chars_data_1year <- chars_data %>%
   filter(meta_year == "2022")
 
-complex_id_data_v2 <- left_join(complex_id_data, chars_data_1year, by = "meta_pin") %>%
-  filter(meta_township_code.x == 35)
+complex_id_data_v2 <- left_join(complex_id_data, chars_data_1year, by = "meta_pin")
 
-# Generating a color palette
 colorPalette <- colorFactor(palette = "viridis", domain = complex_id_data_v2$meta_complex_id)
 
-# Creating a leaflet map with colored markers
 leaflet(complex_id_data_v2) %>%
   addTiles() %>%
   addCircleMarkers(

--- a/reports/_setup.qmd
+++ b/reports/_setup.qmd
@@ -61,6 +61,11 @@ if (!exists("chars_data")) {
   chars_data <- read_parquet(paths$input$char$local)
 }
 
+# Load characteristics data
+if (!exists("complex_id_data")) {
+  complex_id_data <- read_parquet(paths$input$complex_id$local)
+}
+
 
 ## Output data -----------------------------------------------------------------
 


### PR DESCRIPTION
This pull request provides a leaflet map at the bottom of the input portion of the performance quarto. The map is filtered to Schaumburg, a township with a significant number of townhomes, as the full map was laggy and harder to read. The Complex IDs are demonstrated by both the color (which is imprecise) and the number once the individual townhome is clicked on.

Summary of data:

- Within our data, there are 71,223 townhome observations, with 19,925 unique townhome Complex IDs. 

Takeaways:

- It does not appear like the Complex ID works as anticipated. While the IDs are often geographically concentrated, they often represent subsections of complexes. What this means in practice is that if an individual were to identify an expected complex on a map, it is often comprised of multiple Complex IDs, each with very few observations.

