### PR TITLE
Fix `num_iterations` parameter treatment

### DIFF
--- a/params.yaml
+++ b/params.yaml
@@ -289,8 +289,9 @@ model:
     default:
       # Total number of iterations. Usually changed in tandem with learning_rate
       # NOTE: When early stopping is enabled, num_iterations is effectively the
-      # MAXIMUM possible number of iterations
-      num_iterations: 2000
+      # MAXIMUM possible number of iterations. It does not need to be tuned as
+      # the model will always train until the error stops decreasing
+      num_iterations: 2500
       learning_rate: 0.025
 
       # Maximum number of bins for discretizing continuous features. Lower uses

--- a/pipeline/01-train.R
+++ b/pipeline/01-train.R
@@ -70,7 +70,7 @@ message("Initializing LightGBM model")
 # model arguments, which are provided by parsnip's boost_tree()
 lgbm_model <- parsnip::boost_tree(
   stop_iter = params$model$parameter$stop_iter,
-  trees = tune()
+  trees = params$model$hyperparameter$default$num_iterations
 ) %>%
   set_mode("regression") %>%
   set_engine(
@@ -169,7 +169,6 @@ if (cv_enable) {
     hardhat::extract_parameter_set_dials() %>%
     update(
       # nolint start
-      trees               = dials::trees(lgbm_range$num_iterations),
       learning_rate       = lightsnip::learning_rate(lgbm_range$learning_rate),
       max_bin             = lightsnip::max_bin(lgbm_range$max_bin),
       num_leaves          = lightsnip::num_leaves(lgbm_range$num_leaves),
@@ -233,7 +232,7 @@ if (cv_enable) {
         select(-any_of("num_iterations"))
     ) %>%
     bind_cols(
-      select_max_iterations(lgbm_search, metric = params$cv$best_metric)
+      select_iterations(lgbm_search, metric = params$cv$best_metric)
     ) %>%
     bind_cols(
       select_best(lgbm_search, metric = params$cv$best_metric) %>%


### PR DESCRIPTION
This PR makes two small updates to the way the `num_iterations` parameter is handled:

1. The parameter is set statically in `params.yaml` instead of via cross-validation. With early stopping enabled, the optimal number of iterations will automatically be found via a second holdout validation set. Therefore, setting `num_iterations` via CV will cause the model to waste time exploring useless parameter space.
2. Previously, we took the _maximum_ number of iterations for any given CV round. Now, we're taking the mean number of iterations from the round.