### PR TITLE
Recode `sv_is_outlier` NAs as `FALSE` in `00-ingest.R`

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -33,20 +33,20 @@ stages:
     outs:
     - path: input/assessment_data.parquet
       hash: md5
-      md5: a29359e40b97f9c2706e8cce09670277
-      size: 326595000
+      md5: c5b70ad1c34bb754076c63b0270a92fd
+      size: 326610346
     - path: input/char_data.parquet
       hash: md5
-      md5: 69cd21e8c7e822382c04478d3270ab50
-      size: 657666120
+      md5: 92854d7324387bb5c6f99e3abc2a0712
+      size: 657586082
     - path: input/complex_id_data.parquet
       hash: md5
-      md5: d34d453d87baff2a9dc0540e4912f973
-      size: 722794
+      md5: 9bb04bbef9239034daa56d079dd4493b
+      size: 722503
     - path: input/hie_data.parquet
       hash: md5
-      md5: 0ee91ef656ea6ff5f1690aef4de4c088
-      size: 1923354
+      md5: c905e794ce907342944a5240a6a328e6
+      size: 1928811
     - path: input/land_nbhd_rate_data.parquet
       md5: 0a38ffbf4bb153adf7d05e73ee37b3f4
       size: 4524
@@ -55,8 +55,8 @@ stages:
       size: 2109
     - path: input/training_data.parquet
       hash: md5
-      md5: 11f14d5a5382686c56ab79a4f902df77
-      size: 154208607
+      md5: 51cc8a9bf2ad6947de986a4b5075cf9e
+      size: 154270553
   train:
     cmd: Rscript pipeline/01-train.R
     deps:

--- a/pipeline/00-ingest.R
+++ b/pipeline/00-ingest.R
@@ -274,8 +274,11 @@ training_data_clean <- training_data_w_hie %>%
     any_of(col_type_dict$var_name),
     ~ recode_column_type(.x, cur_column())
   )) %>%
+  # Only exclude explicit outliers from training. Sales with missing validation
+  # outcomes will be considered non-outliers
+  mutate(sv_is_outlier = replace_na(sv_is_outlier, FALSE)) %>%
   # Create time/date features using lubridate
-  dplyr::mutate(
+  mutate(
     # Calculate interval periods and time since the start of the sales sample
     time_interval = interval(
       make_date(params$input$min_sale_year, 1, 1),


### PR DESCRIPTION
Sales validation doesn't label sales with missing data as explicitly outliers or not outliers. We only want to exclude explicit outliers from modeling and should treat any that have `NA` values for `sv_is_outlier` as non-outliers.