### PR TITLE
Join nbhd land rates by class in addition to nbhd code

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -33,30 +33,31 @@ stages:
     outs:
     - path: input/assessment_data.parquet
       hash: md5
-      md5: 46e2a12060b37ec5275e24028db9f9b0
-      size: 327257013
+      md5: 6df4800783ff4e92f5f37602d78faa1f
+      size: 327256291
     - path: input/char_data.parquet
       hash: md5
-      md5: 051b1bef702e6d4a83fc5002b11a38c5
-      size: 658620186
+      md5: 8511f06182af02756e940303a798056f
+      size: 659276050
     - path: input/complex_id_data.parquet
       hash: md5
-      md5: 6a848cd459f2db24216cf87a9d94a604
-      size: 721964
+      md5: 0a06f7dbc3205ffa13400f68adb7c129
+      size: 723444
     - path: input/hie_data.parquet
       hash: md5
-      md5: ba9f9ea28cad26501597db5e1951ff6d
-      size: 1912971
+      md5: f097ee2352629f547ad7151ff985f156
+      size: 1922521
     - path: input/land_nbhd_rate_data.parquet
-      md5: 0a38ffbf4bb153adf7d05e73ee37b3f4
-      size: 4524
+      hash: md5
+      md5: 9068415d8a360a708f6b0866d2a8338c
+      size: 6313
     - path: input/land_site_rate_data.parquet
       md5: 7c6d3de25d8ec0d523e2ffd8f7b4e542
       size: 2109
     - path: input/training_data.parquet
       hash: md5
-      md5: 0388045eb81ee2260a2b36c57ba703cb
-      size: 154231718
+      md5: 9ad36e69228fc492c54ea46537f2ffe1
+      size: 154256297
   train:
     cmd: Rscript pipeline/01-train.R
     deps:

--- a/pipeline/00-ingest.R
+++ b/pipeline/00-ingest.R
@@ -445,7 +445,7 @@ land_site_rate_data %>%
   select(meta_pin = pin, meta_class = class, land_rate_per_pin, year) %>%
   write_parquet(paths$input$land_site_rate$local)
 land_nbhd_rate_data %>%
-  select(meta_nbhd = town_nbhd, land_rate_per_sqft) %>%
+  select(meta_nbhd = town_nbhd, meta_class = class, land_rate_per_sqft) %>%
   write_parquet(paths$input$land_nbhd_rate$local)
 
 # Reminder to upload to DVC store

--- a/pipeline/02-assess.R
+++ b/pipeline/02-assess.R
@@ -172,7 +172,7 @@ assessment_pin_data_w_land <- assessment_card_data_round %>%
   left_join(
     land_nbhd_rate,
     by = c("meta_nbhd_code" = "meta_nbhd", "meta_class")
-    ) %>%
+  ) %>%
   mutate(
     pred_pin_final_fmv_land = ceiling(case_when(
       # nolint start

--- a/pipeline/02-assess.R
+++ b/pipeline/02-assess.R
@@ -169,7 +169,10 @@ assessment_pin_data_w_land <- assessment_card_data_round %>%
   ) %>%
   ungroup() %>%
   left_join(land_site_rate, by = "meta_pin") %>%
-  left_join(land_nbhd_rate, by = c("meta_nbhd_code" = "meta_nbhd")) %>%
+  left_join(
+    land_nbhd_rate,
+    by = c("meta_nbhd_code" = "meta_nbhd", "meta_class")
+    ) %>%
   mutate(
     pred_pin_final_fmv_land = ceiling(case_when(
       # nolint start

--- a/pipeline/07-export.R
+++ b/pipeline/07-export.R
@@ -166,6 +166,7 @@ land_nbhd_rate <- dbGetQuery(
   conn = AWS_ATHENA_CONN_JDBC, glue("
   SELECT
       town_nbhd AS meta_nbhd_code,
+      class AS meta_class,
       land_rate_per_sqft
   FROM ccao.land_nbhd_rate
   WHERE year = '{params$assessment$year}'
@@ -176,7 +177,7 @@ land_nbhd_rate <- dbGetQuery(
 # assessment_pin. Carry over improvement values from prior years
 vacant_land_merged <- vacant_land_trans %>%
   left_join(vacant_land_sales_trans, by = "meta_pin") %>%
-  left_join(land_nbhd_rate, by = "meta_nbhd_code") %>%
+  left_join(land_nbhd_rate, by = c("meta_nbhd_code", "meta_class")) %>%
   left_join(
     land %>%
       group_by(meta_pin) %>%


### PR DESCRIPTION
Neighborhood land rates can now differ within neighborhood by class, so they need to be joined to assessment data in the modeling pipeline by class as well as neighborhood.

This PR only addresses the necessary changes to the modeling pipeline. Changes to land rates ingest are [here](https://github.com/ccao-data/data-architecture/pull/174/files#diff-b4e8aa82b9fa1a2d37708a0d4292405c4ca913a2ea9a59f610e7209d339f7610).