### PR TITLE
Disable `build-and-run-model` job status polling and run `cleanup` on branch deletion

### DIFF
--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -67,6 +67,9 @@ jobs:
       # Maximum pipeline runtime. This is slightly below 6 hours, which
       # is the maximum length of any single GitHub Actions job
       role-duration-seconds: 21000
+      # Disable Batch job status polling since this workflow often takes
+      # more than 6 hours
+      poll_for_status: false
     secrets:
       AWS_IAM_ROLE_TO_ASSUME_ARN: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}

--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -67,9 +67,6 @@ jobs:
       # Maximum pipeline runtime. This is slightly below 6 hours, which
       # is the maximum length of any single GitHub Actions job
       role-duration-seconds: 21000
-      # Disable Batch job status polling since this workflow often takes
-      # more than 6 hours
-      poll_for_status: false
     secrets:
       AWS_IAM_ROLE_TO_ASSUME_ARN: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}

--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -57,10 +57,10 @@ jobs:
       # required in order to allow the reusable called workflow to push to
       # GitHub Container Registry
       packages: write
-    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@main
+    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@jeancochrane/fix-concurrent-runs-and-cleanup-of-build-and-run-batch-job
     with:
-      backend: "ec2"
-      vcpu: "32"
+      ref: jeancochrane/fix-concurrent-runs-and-cleanup-of-build-and-run-batch-job
+      vcpu: "16.0"
       memory: "65536"
       # Maximum pipeline runtime. This is slightly below 6 hours, which
       # is the maximum length of any single GitHub Actions job

--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -58,9 +58,8 @@ jobs:
       # required in order to allow the reusable called workflow to push to
       # GitHub Container Registry
       packages: write
-    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@jeancochrane/fix-concurrent-runs-and-cleanup-of-build-and-run-batch-job
+    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@main
     with:
-      ref: jeancochrane/fix-concurrent-runs-and-cleanup-of-build-and-run-batch-job
       backend: "ec2"
       vcpu: "32"
       memory: "65536"

--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -58,11 +58,10 @@ jobs:
       # required in order to allow the reusable called workflow to push to
       # GitHub Container Registry
       packages: write
-    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@jeancochrane/fix-concurrent-runs-and-cleanup-of-build-and-run-batch-job
+    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@main
     with:
-      ref: jeancochrane/fix-concurrent-runs-and-cleanup-of-build-and-run-batch-job
-      backend: ec2
-      vcpu: "16"
+      backend: "ec2"
+      vcpu: "32"
       memory: "65536"
       # Maximum pipeline runtime. This is slightly below 6 hours, which
       # is the maximum length of any single GitHub Actions job

--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -45,6 +45,7 @@ on:
         required: true
   push:
     branches: [master]
+  delete:
 
 jobs:
   build-and-run-model:

--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -58,8 +58,9 @@ jobs:
       # required in order to allow the reusable called workflow to push to
       # GitHub Container Registry
       packages: write
-    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@main
+    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@jeancochrane/fix-concurrent-runs-and-cleanup-of-build-and-run-batch-job
     with:
+      ref: jeancochrane/fix-concurrent-runs-and-cleanup-of-build-and-run-batch-job
       backend: "ec2"
       vcpu: "32"
       memory: "65536"

--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -61,7 +61,8 @@ jobs:
     uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@jeancochrane/fix-concurrent-runs-and-cleanup-of-build-and-run-batch-job
     with:
       ref: jeancochrane/fix-concurrent-runs-and-cleanup-of-build-and-run-batch-job
-      vcpu: "16.0"
+      backend: ec2
+      vcpu: "16"
       memory: "65536"
       # Maximum pipeline runtime. This is slightly below 6 hours, which
       # is the maximum length of any single GitHub Actions job


### PR DESCRIPTION
This PR is the companion of https://github.com/ccao-data/actions/pull/17, making two changes to improve the UX of the `build-and-run-model` workflow:

1. Configures the workflow to run on the `delete` event so that the `cleanup` step can run in the case of branch deletion
2. Disables Batch job status polling, since model runs often exceed 6 hours

Note that similar to https://github.com/ccao-data/actions/pull/17, improvement 1 can't be tested until these changes land on the `main` branch, so I'm planning to test it after merging. See https://github.com/ccao-data/actions/pull/17 for detailed information about testing these changes. 