### PR TITLE
Remove branch delete handler from `build-and-run-model` workflow

### DIFF
--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -45,7 +45,6 @@ on:
         required: true
   push:
     branches: [master]
-  delete:
 
 jobs:
   build-and-run-model:


### PR DESCRIPTION
This PR reverts the change made in https://github.com/ccao-data/model-res-avm/pull/156 to add `delete` event handling to the `build-and-run-model` workflow. It is the companion PR to https://github.com/ccao-data/actions/pull/18. See that PR for more details on this decision.