### PR TITLE
Use all vCPU and memory available to the instance in `build-and-run-model`

### DIFF
--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -60,8 +60,8 @@ jobs:
     uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@main
     with:
       backend: "ec2"
-      vcpu: "32"
-      memory: "65536"
+      vcpu: "40"
+      memory: "158000"
       # Maximum pipeline runtime. This is slightly below 6 hours, which
       # is the maximum length of any single GitHub Actions job
       role-duration-seconds: 21000


### PR DESCRIPTION
This PR tweaks our vCPU/memory allocation in `build-and-run-model` to make full use of the resources available to the EC2 instances we're provisioning.

It turns out that the `BEST_FIT` Batch allocation strategy is always provisioning m4 instances, which have a somewhat unusual distribution of CPU/RAM combinations (see [the docs](https://aws.amazon.com/ec2/instance-types/) for the full table). As a result, the next-biggest instance after 16vCPU/64GB RAM  (m4.4xlarge) has 40 vCPU/160GB RAM (m4.10xlarge). Currently we're requesting 32 vCPU and 64GB RAM, which is causing Batch to provision m4.10xlarge instances in order to fulfill our request for 32 vCPUs; but since the ECS container agent limits the resources available to the container based on the vCPU/memory we request in our job definitions, our job containers only have access to the 32 vCPU/64GB RAM that they request. By bumping these allocations to more closely match the resources available to an m4.10xlarge instance, we get more compute and memory at no extra cost.

I tested these changes by triggering a workflow run and confirming that the EC2 instance that Batch provisions is still a m4.10xlarge.

Note that we also may want to think about changing our allocation strategy and setting specific instance types that we want to provision in order to further control costs; this seems like it's not the biggest priority right now, however, and it would make sense to revisit once we [redesign the pipeline](https://github.com/ccao-data/actions/issues/16) to have preset compute environment sizes anyway. 