### PR TITLE
Improve cross-validation methodology

### DIFF
--- a/dvc.yaml
+++ b/dvc.yaml
@@ -26,7 +26,6 @@ stages:
     - input/training_data.parquet
     params:
     - cv
-    - input.time_split
     - model.engine
     - model.hyperparameter
     - model.objective

--- a/params.yaml
+++ b/params.yaml
@@ -293,9 +293,20 @@ model:
   hyperparameter:
     # Default set of hyperparameters to use if CV is not enabled
     default:
-      # Total number of iterations. Usually changed in tandem with learning_rate
-      # NOTE: If cross-validation is not used, then the model will always train
-      # to exactly this number of iterations, even if early stopping is enabled
+      # Total/maximum number of iterations. Usually changed in tandem with
+      # learning_rate. One of the most important params controlling complexity
+
+      # NOTE: If cross-validation is used and/or early stopping is enabled, then
+      # this is effectively the MAXIMUM number of trees (i.e. the model can stop
+      # before reaching this number), and the number actual used is reported in
+      # the lgbm_final_params object in the train stage and parameter_final
+      # table in the run outputs/Athena
+
+      # If cross-validation / early stopping are disabled then the model will
+      # always train to exactly this number of iterations. The ideal strategy
+      # for setting this parameter is to discover a good upper bound using CV,
+      # then manually set that bound for non-CV runs (which don't use
+      # early stopping by default)
       num_iterations: 1575
       learning_rate: 0.015
 
@@ -319,7 +330,6 @@ model:
 
     # Range of possible hyperparameter values for tuning to explore
     range:
-      num_iterations: [40, 2500]
       learning_rate: [-3.0, -0.4] # 10 ^ X
       max_bin: [50, 512]
       num_leaves: [32, 2048]

--- a/params.yaml
+++ b/params.yaml
@@ -56,9 +56,6 @@ input:
   min_sale_year: "2015"
   max_sale_year: "2023"
 
-  # Time window (in months) used for rolling origin cross-validation
-  time_split: 15
-
   # Parameters used to generate townhome complex identifiers
   complex:
     # Townhomes (class 210/295) should match exactly on these variables to be
@@ -86,12 +83,18 @@ input:
 
 # Cross-validation parameters used in the train stage
 cv:
-  # Proportion of the training data to use for training vs test e.g. 0.9 means
-  # the most recent 10% of sales are used as a test set
+  # Proportion of the training data to use for training vs test, split by time.
+  # 0.9 means the most recent 10% of sales are used as a test set
   split_prop: 0.9
 
-  # Number of folds to use for cross-validation
-  num_folds: 5
+  # Number of folds to use for cross-validation. For v-fold CV, the data will be
+  # randomly split. For rolling-origin, the data will be split into V chunks by
+  # time, with each chunk/period calculated automatically
+  num_folds: 6
+
+  # The number of months time-based folds should overlap each other. Only
+  # applicable to rolling-origin CV. See https://www.tmwr.org/resampling#rolling
+  fold_overlap: 9
 
   # Number of initial iterations to create before tuning. Recommend this number
   # be greater than the number of hyperparameters being tuned
@@ -275,7 +278,7 @@ model:
     # https://lightgbm.readthedocs.io/en/latest/R/reference/lgb.train.html#arguments
     # WARNING: See GitLab issue #82 for critical notes about early stopping / CV
     validation_prop: 0.1
-    validation_type: "random"
+    validation_type: "recent"
     validation_metric: "rmse"
 
     # Custom parameters added by the CCAO's lightsnip wrapper package. Setting

--- a/params.yaml
+++ b/params.yaml
@@ -90,11 +90,11 @@ cv:
   # Number of folds to use for cross-validation. For v-fold CV, the data will be
   # randomly split. For rolling-origin, the data will be split into V chunks by
   # time, with each chunk/period calculated automatically
-  num_folds: 6
+  num_folds: 5
 
   # The number of months time-based folds should overlap each other. Only
   # applicable to rolling-origin CV. See https://www.tmwr.org/resampling#rolling
-  fold_overlap: 9
+  fold_overlap: 18
 
   # Number of initial iterations to create before tuning. Recommend this number
   # be greater than the number of hyperparameters being tuned
@@ -288,7 +288,7 @@ model:
 
     # During CV, the number of iterations to go without improvement before
     # stopping training. Early stopping is deactivated when NULL
-    stop_iter: 40
+    stop_iter: 50
 
   hyperparameter:
     # Default set of hyperparameters to use if CV is not enabled
@@ -307,7 +307,7 @@ model:
       # for setting this parameter is to discover a good upper bound using CV,
       # then manually set that bound for non-CV runs (which don't use
       # early stopping by default)
-      num_iterations: 1575
+      num_iterations: 2500
       learning_rate: 0.015
 
       # Maximum number of bins for discretizing continuous features. Lower uses

--- a/params.yaml
+++ b/params.yaml
@@ -90,11 +90,11 @@ cv:
   # Number of folds to use for cross-validation. For v-fold CV, the data will be
   # randomly split. For rolling-origin, the data will be split into V chunks by
   # time, with each chunk/period calculated automatically
-  num_folds: 5
+  num_folds: 7
 
   # The number of months time-based folds should overlap each other. Only
   # applicable to rolling-origin CV. See https://www.tmwr.org/resampling#rolling
-  fold_overlap: 18
+  fold_overlap: 9
 
   # Number of initial iterations to create before tuning. Recommend this number
   # be greater than the number of hyperparameters being tuned
@@ -104,7 +104,7 @@ cv:
   max_iterations: 50
 
   # Max number of search iterations without improvement before stopping search
-  no_improve: 15
+  no_improve: 24
 
   # The number of iterations with no improvement before an uncertainty sample
   # is created where a sample with high predicted variance is chosen

--- a/pipeline/00-ingest.R
+++ b/pipeline/00-ingest.R
@@ -305,20 +305,7 @@ training_data_clean <- training_data_w_hie %>%
     time_sale_day_of_year = as.integer(yday(meta_sale_date)),
     time_sale_day_of_month = as.integer(day(meta_sale_date)),
     time_sale_day_of_week = as.integer(wday(meta_sale_date)),
-    time_sale_post_covid = meta_sale_date >= make_date(2020, 3, 15),
-    # Time window to use for cross-validation during training. The last X% of
-    # each window is held out as a validation set
-    time_split = time_interval %/% months(params$input$time_split),
-    # Collapse the last 2 splits into their earlier neighbor. This is done
-    # because part of the final time window will be held out for the test set,
-    # which will shrink the last split to the point of being too small for CV
-    time_split = ifelse(
-      time_split > max(time_split) - 2,
-      max(time_split) - 2,
-      time_split
-    ),
-    time_split = as.character(time_split + 1),
-    time_split = factor(time_split, levels = sort(unique(time_split)))
+    time_sale_post_covid = meta_sale_date >= make_date(2020, 3, 15)
   ) %>%
   select(-time_interval) %>%
   relocate(starts_with("sv_"), .after = everything()) %>%

--- a/pipeline/05-finalize.R
+++ b/pipeline/05-finalize.R
@@ -95,6 +95,7 @@ metadata <- tibble::tibble(
   shap_enable = shap_enable,
   cv_enable = cv_enable,
   cv_num_folds = params$cv$num_folds,
+  cv_fold_overlap = params$cv$fold_overlap,
   cv_initial_set = params$cv$initial_set,
   cv_max_iterations = params$cv$max_iterations,
   cv_no_improve = params$cv$no_improve,


### PR DESCRIPTION
This PR updates the rolling-origin/sliding window cross-validation methodology used to choose hyperparameters for the main model. Mainly, it adds a dedicated function to calculate sliding window resamples with the following improvements:

- Can seamlessly swap between `random` (v-fold) and `recent` (sliding window) based CV by setting the `validation_type` parameter. No longer need to change other code
- Sliding window folds can now be non-cumulative i.e. the window is a fixed with and moves forward in time, rather than the window origin always being the start date of the data
- The sliding window can still be made cumulative via a toggle
- Both cumulative and non-cumulative sliding window folds can be made overlapping by N months. The function will shrink or grow the training fold to cover the entire training data with V folds and N months of overlap per fold