### PR TITLE
Add logic for `num_iterations` usage

### DIFF
--- a/R/setup.R
+++ b/R/setup.R
@@ -76,6 +76,10 @@ upload_enable <- as.logical(Sys.getenv(
   "UPLOAD_ENABLE_OVERRIDE",
   unset = get(params_obj_name)$toggle$upload_enable
 ))
+early_stopping_enable <-
+  get(params_obj_name)$model$parameter$validation_prop > 0 &&
+    !is.null(get(params_obj_name)$model$parameter$stop_iter) && # nolint
+    get(params_obj_name)$model$parameter$stop_iter > 0 # nolint
 
 # Load any additional PINs to generate reports for from environment
 report_pins <- unique(c(

--- a/params.yaml
+++ b/params.yaml
@@ -90,11 +90,11 @@ cv:
   # Number of folds to use for cross-validation. For v-fold CV, the data will be
   # randomly split. For rolling-origin, the data will be split into V chunks by
   # time, with each chunk/period calculated automatically
-  num_folds: 7
+  num_folds: 5
 
   # The number of months time-based folds should overlap each other. Only
   # applicable to rolling-origin CV. See https://www.tmwr.org/resampling#rolling
-  fold_overlap: 9
+  fold_overlap: 15
 
   # Number of initial iterations to create before tuning. Recommend this number
   # be greater than the number of hyperparameters being tuned
@@ -104,7 +104,7 @@ cv:
   max_iterations: 50
 
   # Max number of search iterations without improvement before stopping search
-  no_improve: 24
+  no_improve: 15
 
   # The number of iterations with no improvement before an uncertainty sample
   # is created where a sample with high predicted variance is chosen
@@ -296,18 +296,12 @@ model:
       # Total/maximum number of iterations. Usually changed in tandem with
       # learning_rate. One of the most important params controlling complexity
 
-      # NOTE: If cross-validation is used and/or early stopping is enabled, then
-      # this is effectively the MAXIMUM number of trees (i.e. the model can stop
-      # before reaching this number), and the number actual used is reported in
-      # the lgbm_final_params object in the train stage and parameter_final
-      # table in the run outputs/Athena
-
-      # If cross-validation / early stopping are disabled then the model will
+      # If cross-validation and early stopping are disabled then the model will
       # always train to exactly this number of iterations. The ideal strategy
-      # for setting this parameter is to discover a good upper bound using CV,
-      # then manually set that bound for non-CV runs (which don't use
+      # for setting this parameter is to discover a good fixed value using CV,
+      # then manually set that value for non-CV runs (which don't use
       # early stopping by default)
-      num_iterations: 2500
+      num_iterations: 1575
       learning_rate: 0.015
 
       # Maximum number of bins for discretizing continuous features. Lower uses
@@ -330,6 +324,12 @@ model:
 
     # Range of possible hyperparameter values for tuning to explore
     range:
+      # NOTE: If cross-validation is used and/or early stopping is enabled, then
+      # the upper bound for num_iterations is effectively the MAXIMUM number of
+      # trees (i.e. the model can stop before reaching this number), and the
+      # number actual used is reported in the lgbm_final_params object in the
+      # train stage and parameter_final table in the run outputs/Athena
+      num_iterations: [100, 2500]
       learning_rate: [-3.0, -0.4] # 10 ^ X
       max_bin: [50, 512]
       num_leaves: [32, 2048]

--- a/pipeline/01-train.R
+++ b/pipeline/01-train.R
@@ -102,8 +102,7 @@ message("Initializing LightGBM model")
 # lightgbm as "engine arguments" i.e. things specific to lightgbm, as opposed to
 # model arguments, which are provided by parsnip's boost_tree()
 lgbm_model <- parsnip::boost_tree(
-  stop_iter = params$model$parameter$stop_iter,
-  trees = params$model$hyperparameter$default$num_iterations
+  stop_iter = params$model$parameter$stop_iter
 ) %>%
   set_mode("regression") %>%
   set_engine(
@@ -170,6 +169,23 @@ lgbm_model <- parsnip::boost_tree(
     lambda_l2 = tune()
   )
 
+# The num_iterations (trees) parameter has three possible values:
+# 1. If CV AND early stopping are enabled, set a static parameter using the
+#    upper bound of the CV search range as the maximum possible number of trees
+# 2. If CV is enabled but early stopping is disabled, set the search range to
+#    the standard CV range
+# 3. If no CV is enabled, use the default parameter value
+if (cv_enable && early_stopping_enable) {
+  lgbm_model <- lgbm_model %>%
+    set_args(trees = params$model$hyperparameter$range$num_iterations[2])
+} else if (cv_enable && !early_stopping_enable) {
+  lgbm_model <- lgbm_model %>%
+    set_args(trees = tune())
+} else {
+  lgbm_model <- lgbm_model %>%
+    set_args(trees = params$model$hyperparameter$default$num_iterations)
+}
+
 # Initialize lightgbm workflow, which contains both the model spec AND the
 # pre-processing steps/recipe needed to prepare the raw data
 lgbm_wflow <- workflow() %>%
@@ -232,6 +248,12 @@ if (cv_enable) {
       lambda_l2           = lightsnip::lambda_l2(lgbm_range$lambda_l2)
       # nolint end
     )
+
+  # Update the tuning param with the CV range only if early stopping is disabled
+  if (cv_enable && !early_stopping_enable) {
+    lgbm_params <- lgbm_params %>%
+      update(trees = dials::trees(lgbm_range$num_iterations))
+  }
 
   # Use Bayesian tuning to find best performing hyperparameters. This part takes
   # quite a long time, depending on the compute resources available

--- a/pipeline/01-train.R
+++ b/pipeline/01-train.R
@@ -249,8 +249,8 @@ if (cv_enable) {
       # nolint end
     )
 
-  # Update the tuning param with the CV range only if early stopping is disabled
-  if (cv_enable && !early_stopping_enable) {
+  # Only update the tuning param with the CV range if early stopping is disabled
+  if (!early_stopping_enable) {
     lgbm_params <- lgbm_params %>%
       update(trees = dials::trees(lgbm_range$num_iterations))
   }


### PR DESCRIPTION
Quick PR to clarify the behavior of the `num_iterations` hyperparameter and how it interacts with cross-validation. Basically, it can follow 3 paths:

1. If CV AND early stopping are enabled, the training pipeline uses the upper bound of the CV search range (set in `params.yaml`) as the _maximum_ possible number of iterations before stopping. CV could plausibly discover an optimal number of iterations anywhere between 0 and the max by using a holdout validation set
3. If CV is enabled but early stopping is disabled, set the search range to the standard CV range specified in `params.yaml`. CV will iterate through the `num_iterations` range and test different values
3. If no CV is enabled, use the default, static parameter value from `params.yaml`