### PR TITLE
Add `char_class` as a predictor

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -14,7 +14,6 @@ stages:
         input:
           min_sale_year: '2015'
           max_sale_year: '2023'
-          time_split: 15
           complex:
             match_exact:
             - meta_township_code
@@ -33,20 +32,20 @@ stages:
     outs:
     - path: input/assessment_data.parquet
       hash: md5
-      md5: 0fddee28d387b92f60a3cfd8dfa02add
-      size: 321202660
+      md5: 1314a250a23c0c371733ec2f55d4f0de
+      size: 321956184
     - path: input/char_data.parquet
       hash: md5
-      md5: 737e8b1db22c3e356ec4d028e54124ca
-      size: 653325150
+      md5: 3deb6419fee21173bf2bba5b0dd46356
+      size: 654560556
     - path: input/complex_id_data.parquet
       hash: md5
-      md5: 0b8e9fe466be3f7ac4182148bc4e1fea
-      size: 725370
+      md5: 6ceea9007b32fec3fa57d25068877ec2
+      size: 726901
     - path: input/hie_data.parquet
       hash: md5
-      md5: 21aa8c9f509984de75131a9770ab1bac
-      size: 1923255
+      md5: 6823b9ab3a314df9447a92b2cf3f85de
+      size: 1925834
     - path: input/land_nbhd_rate_data.parquet
       hash: md5
       md5: e508daf5790982c303d6503fe1cb8e2b
@@ -56,8 +55,8 @@ stages:
       size: 2109
     - path: input/training_data.parquet
       hash: md5
-      md5: 9fc7aec6eca6ddad17e2aa4cd7a14fd8
-      size: 148003858
+      md5: f9c440288091bcb54d312e28cece5df9
+      size: 148189601
   train:
     cmd: Rscript pipeline/01-train.R
     deps:

--- a/params.yaml
+++ b/params.yaml
@@ -234,6 +234,7 @@ model:
       - "time_sale_day_of_month"
       - "time_sale_day_of_week"
       - "time_sale_post_covid"
+      - "char_class"
 
     # List of predictors included in predictor.all which are categoricals.
     # It is CRITICAL that any categorical variables are included in this list,
@@ -263,6 +264,7 @@ model:
       - "loc_school_elementary_district_geoid"
       - "loc_school_secondary_district_geoid"
       - "time_sale_quarter_of_year"
+      - "char_class"
 
     # List of identifiers for each observation, can be ignored
     id:

--- a/reports/performance/_input.qmd
+++ b/reports/performance/_input.qmd
@@ -309,7 +309,7 @@ input_multicard_test_df <- assessment_card %>%
   ) %>%
   arrange(meta_pin, meta_card_num) %>%
   select(
-    PIN = meta_pin, Class = meta_class, Card = meta_card_num,
+    PIN = meta_pin, Class = char_class, Card = meta_card_num,
     `Card %` = meta_card_pct_total_fmv, SQFT = char_bldg_sf,
     `Card Initial` = pred_card_initial_fmv,
     `Card Final` = pred_card_final_fmv

--- a/reports/performance/_stats.qmd
+++ b/reports/performance/_stats.qmd
@@ -237,7 +237,7 @@ for (i in seq(1, length(stats_ecdfs_grobs_num), by = 6)) {
 
 ```{r _stats_ecdfs_factor}
 stats_ecdfs_plots_fct <- stats_sf_parcels %>%
-  select(where(is.factor)) %>%
+  select(where(is.factor), -contains("class")) %>%
   length()
 
 stats_ecdfs_grobs_fct <- lapply(seq_len(stats_ecdfs_plots_fct), function(index) {


### PR DESCRIPTION
Per run `2024-01-16-hungry-kyra`, it seems that including the class code at the card level slightly improves overall model performance. This PR updates the input data with the new feature, adds it to the appropriate parameters lists, and fixes small breaking changes in the Quarto doc.

Closes #165.