### PR TITLE
Fixup SHAP plots

### DIFF
--- a/reports/performance/_model.qmd
+++ b/reports/performance/_model.qmd
@@ -785,6 +785,8 @@ est_v_actual_plotly_class(test_card, pred_card_initial_fmv_lin)
 - **Frequency** is the percentage representing the relative number of times a particular feature occurs in the trees of the model. In the above example, if `feature1` occurred in 2 splits, 1 split and 3 splits in each of `tree1`, `tree2` and `tree3`; then the weight for `feature1` will be `2 + 1 + 3 = 6`. The frequency for `feature1` is calculated as its percentage weight over weights of all features.
 
 _NOTE: These metrics apply to ALL triads, not just the triad being re-assessed._
+  
+***CRITICAL NOTE: Feature importance metrics for categorical features do not always align with reality/intuition when mixed with numeric predictors. Use the SHAP feature importance metrics below if available. See [here](https://www.kaggle.com/code/mlisovyi/beware-of-categorical-features-in-lgbm) for a minimal example of this behavior.***
 
 ```{r _model_feature_importance_function}
 # Feature importance bar chart function

--- a/reports/performance/_shap.qmd
+++ b/reports/performance/_shap.qmd
@@ -7,66 +7,26 @@ They represent both the direction and magnitude of a feature's impact on an indi
 property's predicted value. Summed together, the SHAP values of all features for a given
 property should equal the difference between the predicted value and the baseline value.
 
-## Summary Table
+## Overall Feature Importance
 
 ```{r _shap_filtering, warning=FALSE}
+shap_predictors <- unlist(metadata$model_predictor_all_name)
+
 shap_df_filtered <- shap_df %>%
-  left_join(
-    assessment_card %>%
-      mutate(meta_triad = ccao::town_get_triad(as.character(township_code))) %>%
-      select(meta_year, meta_pin, meta_card_num, meta_triad),
-    by = c("meta_year", "meta_pin", "meta_card_num")
-  ) %>%
+  mutate(meta_triad = ccao::town_get_triad(as.character(township_code))) %>%
   filter(meta_triad == run_triad_code) %>%
   arrange(meta_pin, meta_card_num)
-```
 
-```{r _shap_table}
-shap_df_filtered %>%
-  select(
-    where(~ !all(is.na(.x))) & !starts_with("pred") & where(is.numeric)
-  ) %>%
-  skim() %>%
-  rename_with(~ str_replace_all(.x, "skim_|numeric.", "")) %>%
-  select(-c(type, n_missing, complete_rate, p25, p75)) %>%
-  rename(histogram = hist, median = p50, min = p0, max = p100) %>%
-  mutate(across(where(is.numeric), ~ round(.x, 1))) %>%
-  left_join(feat_imp_df, by = c("variable" = "model_predictor_all_name")) %>%
-  arrange(desc(gain_value)) %>%
-  select(
-    "Variable" = variable,
-    "Mean" = mean,
-    "Median" = median,
-    "SD" = sd,
-    "Min" = min,
-    "Max" = max,
-    "Histogram" = histogram
-  ) %>%
-  mutate(across(Mean:Max, scales::dollar)) %>%
-  datatable(
-    rownames = FALSE,
-    options = list(
-      columnDefs = list(
-        list(
-          className = "dt-nowrap dt-right",
-          targets = c(1:5)
-        )
-      )
-    )
+shap_df_filtered_long <- shap_df_filtered %>%
+  select(township_code, all_of(shap_predictors)) %>%
+  pivot_longer(
+    cols = all_of(shap_predictors),
+    names_to = "feature",
+    values_to = "shap"
   )
 ```
 
 ```{r _shap_function}
-shap_predictors <- names(shap_df_filtered)
-shap_predictors <- shap_predictors[!shap_predictors %in% c(
-  "meta_year",
-  "meta_pin",
-  "meta_card_num",
-  "pred_card_shap_baseline_fmv",
-  "township_code",
-  "meta_triad"
-)]
-
 assessment_card_filtered <- assessment_card %>%
   mutate(meta_triad = ccao::town_get_triad(as.character(township_code))) %>%
   filter(meta_triad == run_triad_code) %>%
@@ -86,16 +46,40 @@ create_shapviz <- function(shap_df, assessment_df, idx) {
 }
 ```
 
-## Overall Beeswarm
+```{r _shap_triad_table}
+shap_df_filtered_long %>%
+  group_by(feature) %>%
+  summarize(
+    `Mean Abs.` = mean(abs(shap)),
+    `Median Abs.` = median(abs(shap)),
+    Mean = mean(shap),
+    Median = median(shap),
+    SD = sd(shap),
+    `Min.` = min(shap),
+    `Max.` = max(shap)
+  ) %>%
+  mutate(`Rel. Imp.` = `Mean Abs.` / sum(`Mean Abs.`)) %>%
+  relocate(`Rel. Imp.`, .after = feature) %>%
+  arrange(desc(`Mean Abs.`)) %>%
+  mutate(
+    across(`Mean Abs.`:`Max.`, ~ scales::dollar(.x, accuracy = 0.01)),
+    `Rel. Imp.` = scales::percent(`Rel. Imp.`, accuracy = 0.01)
+  ) %>%
+  rename(Feature = feature) %>%
+  datatable(
+    rownames = FALSE,
+    options = list(
+      columnDefs = list(
+        list(
+          className = "dt-nowrap dt-right",
+          targets = c(1:8)
+        )
+      )
+    )
+  )
+```
 
-The [beeswarm plot](https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/beeswarm.html)
-displays an information-dense summary of how features impact the model’s output.
-
-Each property is represented by a single dot on each feature facet. The x position of the dot is
-determined by the SHAP value of that feature, and dots “pile up” along each feature row to show
-density. Color is used to display the original value of the feature. 
-
-```{r _shap_beeswarm_overall, warning=FALSE}
+```{r _shap_triad_plot, warning=FALSE}
 shap_townships_list <- shap_df_filtered %>%
   distinct(township_code) %>%
   pull() %>%
@@ -116,19 +100,69 @@ shapviz::shapviz(
   baseline = shap_df_filtered$pred_card_shap_baseline_fmv[1]
 ) %>%
   shapviz::sv_importance(
-    "beeswarm",
-    max_display = 15L
+    kind = "bar",
+    max_display = 25L
+  ) +
+  labs(x = "Mean Abs. SHAP Value") +
+  scale_x_continuous(
+    labels = scales::dollar,
+    expand = expansion(mult = c(0, 0.1))
   ) +
   theme_minimal() +
-  coord_cartesian(xlim = c(-150000, 300000)) +
-  scale_x_continuous(labels = scales::dollar)
+  theme(
+    axis.text.x = element_text(angle = 45, hjust = 1),
+    axis.title.x = element_text(margin = margin(t = 10))
+  )
 ```
 
-## Beeswarm Per Township
+## Feature Importance by Township
+
+```{r _shap_township_table}
+shap_df_filtered_long %>%
+  group_by(feature, township_code) %>%
+  summarize(
+    `Mean Abs.` = mean(abs(shap)),
+    `Median Abs.` = median(abs(shap)),
+    Mean = mean(shap),
+    Median = median(shap),
+    SD = sd(shap),
+    `Min.` = min(shap),
+    `Max.` = max(shap)
+  ) %>%
+  mutate(
+    `Rel. Imp.` = `Mean Abs.` / sum(`Mean Abs.`),
+    township_code = ccao::town_convert(as.character(township_code))
+  ) %>%
+  relocate(township_code, .before = everything()) %>%
+  relocate(`Rel. Imp.`, .after = feature) %>%
+  arrange(township_code, desc(`Mean Abs.`)) %>%
+  mutate(
+    across(`Mean Abs.`:`Max.`, ~ scales::dollar(.x, accuracy = 0.01)),
+    `Rel. Imp.` = scales::percent(`Rel. Imp.`, accuracy = 0.01)
+  ) %>%
+  rename(Township = township_code, Feature = feature) %>%
+  datatable(
+    rownames = FALSE,
+    filter = "top",
+    options = list(
+      columnDefs = list(
+        list(
+          className = "dt-nowrap dt-right",
+          targets = c(2:9),
+          searchable = FALSE
+        ),
+        list(
+          className = "dt-nowrap",
+          targets = 0
+        )
+      )
+    )
+  )
+```
 
 ::: {.panel-tabset}
 
-```{r _shap_beeswarm_iterate_township, results='asis', warning=FALSE}
+```{r _shap_township_plot, results='asis', warning=FALSE}
 # Dynamically produce tabset
 for (township in shap_townships_list) {
   cat("##", ccao::town_convert(township), "\n")
@@ -142,12 +176,19 @@ for (township in shap_townships_list) {
       shap_idx
     ) %>%
       shapviz::sv_importance(
-        "beeswarm",
-        max_display = 15L
+        kind = "bar",
+        max_display = 25L
+      ) +
+      labs(x = "Mean Abs. SHAP Value") +
+      scale_x_continuous(
+        labels = scales::dollar,
+        expand = expansion(mult = c(0, 0.1))
       ) +
       theme_minimal() +
-      coord_cartesian(xlim = c(-150000, 300000)) +
-      scale_x_continuous(labels = scales::dollar)
+      theme(
+        axis.text.x = element_text(angle = 45, hjust = 1),
+        axis.title.x = element_text(margin = margin(t = 10))
+      )
   )
   cat("\n\n")
 }

--- a/reports/performance/_shap.qmd
+++ b/reports/performance/_shap.qmd
@@ -9,6 +9,8 @@ property should equal the difference between the predicted value and the baselin
 
 ## Overall Feature Importance
 
+Aggregate feature importance scores ***for the target triad***. The length of the bars corresponds to the `Mean Abs.` column in the table below.
+
 ```{r _shap_filtering, warning=FALSE}
 shap_predictors <- unlist(metadata$model_predictor_all_name)
 
@@ -44,39 +46,6 @@ create_shapviz <- function(shap_df, assessment_df, idx) {
     baseline = shap_df_filtered$pred_card_shap_baseline_fmv[1]
   )
 }
-```
-
-```{r _shap_triad_table}
-shap_df_filtered_long %>%
-  group_by(feature) %>%
-  summarize(
-    `Mean Abs.` = mean(abs(shap)),
-    `Median Abs.` = median(abs(shap)),
-    Mean = mean(shap),
-    Median = median(shap),
-    SD = sd(shap),
-    `Min.` = min(shap),
-    `Max.` = max(shap)
-  ) %>%
-  mutate(`Rel. Imp.` = `Mean Abs.` / sum(`Mean Abs.`)) %>%
-  relocate(`Rel. Imp.`, .after = feature) %>%
-  arrange(desc(`Mean Abs.`)) %>%
-  mutate(
-    across(`Mean Abs.`:`Max.`, ~ scales::dollar(.x, accuracy = 0.01)),
-    `Rel. Imp.` = scales::percent(`Rel. Imp.`, accuracy = 0.01)
-  ) %>%
-  rename(Feature = feature) %>%
-  datatable(
-    rownames = FALSE,
-    options = list(
-      columnDefs = list(
-        list(
-          className = "dt-nowrap dt-right",
-          targets = c(1:8)
-        )
-      )
-    )
-  )
 ```
 
 ```{r _shap_triad_plot, warning=FALSE}
@@ -115,11 +84,9 @@ shapviz::shapviz(
   )
 ```
 
-## Feature Importance by Township
-
-```{r _shap_township_table}
+```{r _shap_triad_table}
 shap_df_filtered_long %>%
-  group_by(feature, township_code) %>%
+  group_by(feature) %>%
   summarize(
     `Mean Abs.` = mean(abs(shap)),
     `Median Abs.` = median(abs(shap)),
@@ -129,36 +96,28 @@ shap_df_filtered_long %>%
     `Min.` = min(shap),
     `Max.` = max(shap)
   ) %>%
-  mutate(
-    `Rel. Imp.` = `Mean Abs.` / sum(`Mean Abs.`),
-    township_code = ccao::town_convert(as.character(township_code))
-  ) %>%
-  relocate(township_code, .before = everything()) %>%
+  mutate(`Rel. Imp.` = `Mean Abs.` / sum(`Mean Abs.`)) %>%
   relocate(`Rel. Imp.`, .after = feature) %>%
-  arrange(township_code, desc(`Mean Abs.`)) %>%
+  arrange(desc(`Mean Abs.`)) %>%
   mutate(
     across(`Mean Abs.`:`Max.`, ~ scales::dollar(.x, accuracy = 0.01)),
     `Rel. Imp.` = scales::percent(`Rel. Imp.`, accuracy = 0.01)
   ) %>%
-  rename(Township = township_code, Feature = feature) %>%
+  rename(Feature = feature) %>%
   datatable(
     rownames = FALSE,
-    filter = "top",
     options = list(
       columnDefs = list(
         list(
           className = "dt-nowrap dt-right",
-          targets = c(2:9),
-          searchable = FALSE
-        ),
-        list(
-          className = "dt-nowrap",
-          targets = 0
+          targets = c(1:8)
         )
       )
     )
   )
 ```
+
+## Feature Importance by Township
 
 ::: {.panel-tabset}
 
@@ -195,3 +154,48 @@ for (township in shap_townships_list) {
 ```
 
 :::
+
+```{r _shap_township_table}
+shap_df_filtered_long %>%
+  group_by(feature, township_code) %>%
+  summarize(
+    `Mean Abs.` = mean(abs(shap)),
+    `Median Abs.` = median(abs(shap)),
+    Mean = mean(shap),
+    Median = median(shap),
+    SD = sd(shap),
+    `Min.` = min(shap),
+    `Max.` = max(shap)
+  ) %>%
+  ungroup() %>%
+  mutate(
+    `Rel. Imp.` = `Mean Abs.` / sum(`Mean Abs.`),
+    township_code = ccao::town_convert(as.character(township_code)),
+    .by = township_code
+  ) %>%
+  relocate(township_code, .before = everything()) %>%
+  relocate(`Rel. Imp.`, .after = feature) %>%
+  arrange(township_code, desc(`Mean Abs.`)) %>%
+  mutate(
+    across(`Mean Abs.`:`Max.`, ~ scales::dollar(.x, accuracy = 0.01)),
+    `Rel. Imp.` = scales::percent(`Rel. Imp.`, accuracy = 0.01)
+  ) %>%
+  rename(Township = township_code, Feature = feature) %>%
+  datatable(
+    rownames = FALSE,
+    filter = "top",
+    options = list(
+      columnDefs = list(
+        list(
+          className = "dt-nowrap dt-right",
+          targets = c(2:9),
+          searchable = FALSE
+        ),
+        list(
+          className = "dt-nowrap",
+          targets = 0
+        )
+      )
+    )
+  )
+```

--- a/reports/pin/_shap.qmd
+++ b/reports/pin/_shap.qmd
@@ -78,7 +78,7 @@ for (i in 1:num_rows) {
   cat("##", "Card ", shap_df_filtered$meta_card_num[i], "\n")
 
   results[[i]] <- create_shap_viz(i) +
-    scale_x_continuous(labels = scales::dollar)
+    scale_x_continuous(labels = scales::dollar, expand = c(0.1, 0))
 
   print(results[[i]])
 

--- a/reports/pin/_shap.qmd
+++ b/reports/pin/_shap.qmd
@@ -3,37 +3,25 @@
 ## SHAP Values
 
 ```{r _pin_shap_data_manipulation}
-shap_df_filtered <- shap_df %>%
-  left_join(
-    assessment_card %>%
-      mutate(meta_triad = ccao::town_get_triad(as.character(township_code))) %>%
-      select(meta_year, meta_pin, meta_card_num, meta_triad),
-    by = c("meta_year", "meta_pin", "meta_card_num"),
-    relationship = "many-to-many"
-  ) %>%
-  arrange(meta_pin, meta_card_num)
+shap_predictors <- unlist(metadata$model_predictor_all_name)
 
-shap_predictors <- names(shap_df_filtered)
-shap_predictors <- shap_predictors[!shap_predictors %in% c(
-  "meta_year",
-  "meta_pin",
-  "meta_card_num",
-  "pred_card_shap_baseline_fmv",
-  "township_code",
-  "meta_triad"
-)]
+shap_df_filtered <- shap_df %>%
+  mutate(meta_triad = ccao::town_get_triad(as.character(township_code))) %>%
+  filter(meta_triad == run_triad_code) %>%
+  arrange(meta_pin, meta_card_num)
 
 assessment_card_filtered <- assessment_card %>%
   mutate(meta_triad = ccao::town_get_triad(as.character(township_code))) %>%
+  filter(meta_triad == run_triad_code) %>%
   arrange(meta_pin, meta_card_num)
 
-townships_to_iterate <- shap_df_filtered %>%
+shap_townships_to_iterate <- shap_df_filtered %>%
   distinct(township_code) %>%
   pull() %>%
   as.character()
 
 shap_idx_full_model <- which(
-  assessment_card_filtered$meta_township_code %in% townships_to_iterate
+  assessment_card_filtered$meta_township_code %in% shap_townships_to_iterate
 )
 
 shap_df_filtered <- shap_df_filtered %>%
@@ -59,26 +47,33 @@ create_shap_viz <- function(row_idx) {
       slice(row_idx),
     baseline = shap_df_filtered$pred_card_shap_baseline_fmv[1]
   ) %>%
-    sv_waterfall(
-      max_display = 15L
-    )
+    sv_waterfall(max_display = 15L)
 
   return(shapviz_object)
 }
 
-num_rows <- nrow(shap_df_filtered)
+shap_num_rows <- nrow(shap_df_filtered)
 ```
 
 ::: {.panel-tabset}
 
 ```{r _pin_shap_results, results = 'asis'}
-results <- vector("list", length = num_rows)
+results <- vector("list", length = shap_num_rows)
 
-for (i in 1:num_rows) {
+for (i in seq_len(shap_num_rows)) {
   cat("##", "Card ", shap_df_filtered$meta_card_num[i], "\n")
 
   results[[i]] <- create_shap_viz(i) +
-    scale_x_continuous(labels = scales::dollar, expand = c(0.1, 0))
+    labs(x = "Mean Abs. SHAP Value") +
+    scale_x_continuous(
+      labels = scales::dollar,
+      expand = expansion(mult = c(0.05, 0.1))
+    ) +
+    theme_minimal() +
+    theme(
+      axis.text.x = element_text(angle = 45, hjust = 1),
+      axis.title.x = element_text(margin = margin(t = 10))
+    )
 
   print(results[[i]])
 

--- a/reports/pin/_shap.qmd
+++ b/reports/pin/_shap.qmd
@@ -98,29 +98,51 @@ shap_df_filtered %>%
   select_if(is.numeric) %>%
   select(-any_of("township_code")) %>%
   mutate(
-    `Chars.` = rowSums(select(., starts_with("char")), na.rm = TRUE),
-    ACS5 = rowSums(select(., starts_with("acs5")), na.rm = TRUE),
-    Time = rowSums(select(., starts_with("time")), na.rm = TRUE),
-    Location = rowSums(select(., starts_with("loc")), na.rm = TRUE) +
-      ccao_is_corner_lot - loc_school_secondary_district_geoid -
-      loc_school_elementary_district_geoid + other_tax_bill_rate,
-    Proximity = rowSums(select(., starts_with("prox")), na.rm = TRUE),
+    `Chars.` = rowSums(select(., starts_with("char_")), na.rm = TRUE),
+    ACS5 = rowSums(select(., starts_with("acs5_")), na.rm = TRUE),
+    Time = rowSums(select(., starts_with("time_")), na.rm = TRUE),
+    Location = rowSums(select(
+      .,
+      starts_with("loc_"),
+      -any_of(c(
+        "loc_school_elementary_district_geoid",
+        "loc_school_secondary_district_geoid"
+      )),
+      any_of(c("ccao_is_corner_lot", "other_tax_bill_rate"))
+    ), na.rm = TRUE),
+    Proximity = rowSums(select(., starts_with("prox_")), na.rm = TRUE),
     School = rowSums(select(., any_of(c(
       "other_school_district_elementary_avg_rating",
       "other_school_district_secondary_avg_rating",
       "loc_school_elementary_district_geoid",
       "loc_school_secondary_district_geoid"
     ))), na.rm = TRUE),
-    Baseline = pred_card_shap_baseline_fmv,
-    Meta = rowSums(select(., starts_with("meta")), na.rm = TRUE)
+    Meta = rowSums(select(., starts_with("meta_")), na.rm = TRUE),
+    Other = rowSums(select(
+      .,
+      -starts_with("char_"),
+      -starts_with("acs5_"),
+      -starts_with("time_"),
+      -starts_with("loc_"),
+      -starts_with("prox_"),
+      -starts_with("meta_"),
+      -any_of(c(
+        "other_school_district_elementary_avg_rating",
+        "other_school_district_secondary_avg_rating",
+        "ccao_is_corner_lot",
+        "other_tax_bill_rate"
+      )),
+      -any_of(c("PIN", "Card", "pred_card_shap_baseline_fmv"))
+    ), na.rm = TRUE)
   ) %>%
   arrange(PIN, Card) %>%
   select(
-    Card, Baseline, `Chars.`, ACS5, Time,
-    Location, Proximity, School, Meta
+    Card,
+    Baseline = pred_card_shap_baseline_fmv, `Chars.`, ACS5, Time,
+    Location, Proximity, School, Other, Meta
   ) %>%
   mutate(across(2:ncol(.), ~ scales::dollar(.x, accuracy = 1))) %>%
-  kable(align = "lrrrrrrrr") %>%
+  kable(align = "lrrrrrrrrr") %>%
   kable_styling(
     "striped",
     position = "left",

--- a/reports/pin/_shap.qmd
+++ b/reports/pin/_shap.qmd
@@ -96,7 +96,7 @@ shap_df_filtered %>%
   mutate(PIN = as.numeric(meta_pin)) %>%
   mutate(Card = as.numeric(meta_card_num)) %>%
   select_if(is.numeric) %>%
-  select(-township_code) %>%
+  select(-any_of("township_code")) %>%
   mutate(
     `Chars.` = rowSums(select(., starts_with("char")), na.rm = TRUE),
     ACS5 = rowSums(select(., starts_with("acs5")), na.rm = TRUE),


### PR DESCRIPTION
Quick PR to fix up some of the SHAP plots. This PR:

- Fixes the scales and limits on the waterfall plot for individual PINs
- Corrects some data aggregation and filtering issues that were causing the individual PIN report not to render
- Switches the beeswarm plots for importance bar charts, in light of [this](https://www.kaggle.com/code/mlisovyi/beware-of-categorical-features-in-lgbm)
- Rebuilds the summary tables to match the importance bar charts