### PR TITLE
Fix initial score calculation for comps

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -186,7 +186,7 @@ extract_num_iterations <- function(x) {
 # the model was trained with the `valids` parameter set such that error metrics
 # are saved for each tree on the model$record_evals attribute. The output
 # weights are useful for computing comps using leaf node assignments
-extract_weights <- function(model, init_score, metric = "rmse") {
+extract_tree_weights <- function(model, init_score, metric = "rmse") {
   # Index into the errors list, and un-list so it is a flat/1dim list
   record_evals <- model$record_evals
   errors <- unlist(record_evals$tree_errors[[metric]]$eval)
@@ -198,6 +198,23 @@ extract_weights <- function(model, init_score, metric = "rmse") {
   weights <- diff_in_errors / sum(diff_in_errors)
 
   return(weights)
+}
+
+# Find an initial validation metric score for use with extract_tree_weights
+# function. For regression models this seems to be the validation metric as
+# calculated using the mean outcome variable
+get_init_score <- function(truth, estimate, metric = "rmse", ...) {
+  stopifnot(metric %in% c("rmse", "mae", "mape"))
+  if (length(estimate) == 1) estimate <- rep(estimate, length(truth))
+  metric_fun <- switch(metric,
+    rmse = yardstick::rmse_vec,
+    mae = yardstick::mae_vec,
+    mape = yardstick::mape_vec
+  )
+
+  out <- metric_fun(truth, estimate, ...)
+
+  return(out)
 }
 
 # Given the result of a CV search, get the number of iterations from the

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -116,7 +116,7 @@ lightgbm::lgb.importance(lgbm_final_full_fit$fit) %>%
 
 
 #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-# 4. Find Comparables  ---------------------------------------------------------
+# 5. Find Comparables  ---------------------------------------------------------
 #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 if (comp_enable) {
@@ -153,11 +153,17 @@ if (comp_enable) {
     filter(!ind_pin_is_multicard, !sv_is_outlier) %>%
     as_tibble()
 
-  tree_weights <- extract_weights(
+  tree_weights <- extract_tree_weights(
     model = lgbm_final_full_fit$fit,
-    init_score = mean(training_data$meta_sale_price, na.rm = TRUE),
-    metric = params$model$objective
+    init_score = get_init_score(
+      training_data$meta_sale_price,
+      mean(training_data$meta_sale_price, na.rm = TRUE),
+      metric = params$model$parameter$validation_metric,
+      na.rm = TRUE
+    ),
+    metric = params$model$parameter$validation_metric
   )
+
   if (length(tree_weights) == 0 || sum(tree_weights) != 1) {
     stop("Unable to extract tree weights: length 0 or weight sum != 1")
   }


### PR DESCRIPTION
@jeancochrane This is a fast-follow on the comps PR merges.

One issue I'm seeing with the comps so far is their matching score is _heavily_ dependent on matching on the very first tree. This intuitively makes sense as the first tree is likely going to be the most informative. However, I'm seeing weights of ~20% on the first tree, which is unlikely to be correct (depending on the learning rate).

I think the mistake is using mean sale price as the "initial score" when we should be using `RMSE(truth = sale_price, estimate = mean_sale_price)`. Using the mean sale price makes no sense in this case, as we're comparing the mean outcome variable to RMSE (or any other validation metric we switch to).

The fix is simply to calculate the initial score using the validation metric, comparing the outcome to the mean outcome.

Sidebar: I think my confusion here came from LightGBM's use of `init_score`. When printing with verbose output, we see something like:

```
[LightGBM] [Info] Total Bins 26169
[LightGBM] [Info] Number of data points in the train set: 363988, number of used features: 96
[LightGBM] [Info] Start training from score 341882.286672
[LightGBM] [Debug] Trained a tree with leaves = 185 and depth = 11
[1]:  tree_errors's rmse:286448 
[LightGBM] [Debug] Trained a tree with leaves = 185 and depth = 11
[2]:  tree_errors's rmse:263736 
```

That `341882.28` in the `Start training from score` line is [the mean](https://github.com/microsoft/LightGBM/blob/252828fd86627d7405021c3377534d6a8239dd69/src/objective/regression_objective.hpp#L173). I guess my brain saw the "initial score" part and decided using the mean value as the score for the weights was correct.