### PR TITLE
Return to using production sales validation flags

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -33,20 +33,20 @@ stages:
     outs:
     - path: input/assessment_data.parquet
       hash: md5
-      md5: 76541ac2f4fc1e4de9f88803fa1717fa
-      size: 309721161
+      md5: 42e81cc1538a27b450c192b4833813af
+      size: 309469015
     - path: input/char_data.parquet
       hash: md5
-      md5: d5dff8f19cb692bfcb105769b144a543
-      size: 614448314
+      md5: 5f2df044bf430b9a18fb7d1a227e7a2a
+      size: 613545531
     - path: input/complex_id_data.parquet
       hash: md5
-      md5: 9a47a97b79b0082e8b3bbf1580ef813f
-      size: 703369
+      md5: 3446ab32a326a84af685ada011360b89
+      size: 702447
     - path: input/hie_data.parquet
       hash: md5
-      md5: 4ee645f892417c25a6e74433017754f6
-      size: 1923160
+      md5: 1c3aa992ee114a0496c14af9164d75fd
+      size: 1917509
     - path: input/land_nbhd_rate_data.parquet
       hash: md5
       md5: e508daf5790982c303d6503fe1cb8e2b
@@ -56,8 +56,8 @@ stages:
       size: 2109
     - path: input/training_data.parquet
       hash: md5
-      md5: 8f7f4b73cc0b056a5c1fde119a5da268
-      size: 156857117
+      md5: 7557266feb8f283ce65574fd0fefb9f3
+      size: 156911134
   train:
     cmd: Rscript pipeline/01-train.R
     deps:

--- a/pipeline/00-ingest.R
+++ b/pipeline/00-ingest.R
@@ -63,25 +63,6 @@ training_data <- dbGetQuery(
 )
 tictoc::toc()
 
-# NOTE: This is a temporary shim to insert updated sales validation flags
-# that use slightly different groupings/methods vs the production flags. This
-# will be replaced once the production flags are stable
-sales_flags <- read_parquet(paste0(
-  "s3://ccao-ci-test-township-partition-data-warehouse-us-east-1",
-  "/sale/flag/2024-01-22_11:55-charming-damon.parquet"
-))
-
-# Replace the old flags with the new flags by reference
-library(data.table)
-conflicts_prefer(dplyr::between)
-conflict_prefer_all("lubridate")
-setDT(training_data)
-setDT(sales_flags)
-
-training_data[sales_flags, c("sv_is_outlier", "sv_outlier_type") := {
-  .(i.sv_is_outlier, i.sv_outlier_type)
-}, on = .(meta_sale_document_num)]
-
 # Pull all ADDCHARS/HIE data. These are Home Improvement Exemptions (HIEs)
 # stored in the legacy (AS/400) data system
 tictoc::tic("HIE data pulled")

--- a/pipeline/00-ingest.R
+++ b/pipeline/00-ingest.R
@@ -288,11 +288,12 @@ training_data_clean <- training_data_w_hie %>%
     across(starts_with("loc_tax_"), \(x) str_replace_all(x, "\\[|\\]", "")),
     across(starts_with("loc_tax_"), \(x) str_trim(str_split_i(x, ",", 1))),
     across(starts_with("loc_tax_"), \(x) na_if(x, "")),
-    # Miscellanous column-level cleanup
+    # Miscellaneous column-level cleanup
     ccao_is_corner_lot = replace_na(ccao_is_corner_lot, FALSE),
     ccao_is_active_exe_homeowner = replace_na(ccao_is_active_exe_homeowner, 0L),
     ccao_n_years_exe_homeowner = replace_na(ccao_n_years_exe_homeowner, 0L),
-    across(where(is.character), \(x) na_if(x, ""))
+    across(where(is.character), \(x) na_if(x, "")),
+    across(where(bit64::is.integer64), \(x) as.numeric(x))
   ) %>%
   # Get a count of the number of sales that have occurred in the last n years
   left_join(
@@ -371,7 +372,8 @@ assessment_data_clean <- assessment_data_w_hie %>%
     ccao_is_corner_lot = replace_na(ccao_is_corner_lot, FALSE),
     ccao_is_active_exe_homeowner = replace_na(ccao_is_active_exe_homeowner, 0L),
     ccao_n_years_exe_homeowner = replace_na(ccao_n_years_exe_homeowner, 0L),
-    across(where(is.character), \(x) na_if(x, ""))
+    across(where(is.character), \(x) na_if(x, "")),
+    across(where(bit64::is.integer64), \(x) as.numeric(x))
   ) %>%
   # Get a count of the number of sales that have occurred in the last n years
   left_join(


### PR DESCRIPTION
This PR removes the shim used to insert temporary city-only sales validation flags into the input data. It replaces them with the finalized flags which are now in production in the `sale.flag` table.