### PR TITLE
Don't `var_encode` the `char_apts` predictor in the model API workbook

### DIFF
--- a/pipeline/08-api.R
+++ b/pipeline/08-api.R
@@ -94,7 +94,14 @@ for (town in towns) {
       across(where(is.numeric), ~ round(.x, 8)),
       meta_pin = ccao::pin_format_pretty(meta_pin, full_length = TRUE)
     ) %>%
-    var_encode(cols = starts_with("char_"))
+    var_encode(
+      # The column selection here is a little hacky, but gets around the fact
+      # that the `cols` attribute can't handle a select clause
+      # like `(starts_with(x) & !y)`
+      cols = card_data %>%
+        select(starts_with("char_") & !char_apts) %>%
+        names()
+    )
 
   # Load workbook and styles
   wb <- loadWorkbook(here("misc", "model_api_template.xlsm"))


### PR DESCRIPTION
One small fix to the model API workbook following #208: as of this year, `char_apts` is not encoded when passed to the model as an input, so we need to adjust the API workbook generation code to ensure we're matching that behavior when populating the Card sheet.