### PR TITLE
[Do not merge] Spike upgrading comps algorithm with taichi

### DIFF
--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -72,7 +72,6 @@ jobs:
     uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@main
     with:
       backend: "ec2"
-      gpu: "4"
       vcpu: "40"
       memory: "158000"
       # Maximum pipeline runtime. This is slightly below 6 hours, which

--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -72,6 +72,7 @@ jobs:
     uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@main
     with:
       backend: "ec2"
+      gpu: "4"
       vcpu: "40"
       memory: "158000"
       # Maximum pipeline runtime. This is slightly below 6 hours, which

--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -69,12 +69,12 @@ jobs:
       # required in order to allow the reusable called workflow to push to
       # GitHub Container Registry
       packages: write
-    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@main
+    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@jeancochrane/spike-c5-instances-for-build-and-run-batch-job
     with:
+      ref: jeancochrane/spike-c5-instances-for-build-and-run-batch-job
       backend: "ec2"
-      gpu: "4"
-      vcpu: "40"
-      memory: "158000"
+      vcpu: "90"
+      memory: "180000"
       # Maximum pipeline runtime. This is slightly below 6 hours, which
       # is the maximum length of any single GitHub Actions job
       role-duration-seconds: 21000

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,4 @@ COPY ./ .
 RUN rm -Rf /model-res-avm/renv && \
     mv /setup/renv /model-res-avm/renv
 
-CMD dvc pull && dvc repro
+CMD python3 python/comps.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime
 
+# Install system dependencies
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        libx11-dev
+
 # Copy Python requirements file into the image
 COPY requirements.txt ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,10 @@
-FROM rocker/r-ver:4.3.2
+FROM pytorch/2.3.0-cuda12.1-cudnn8-runtime
 
-# Set the working directory to setup. Uses a dedicated directory instead of
-# root since otherwise renv will try to scan every subdirectory
-WORKDIR /setup
+# Copy Python requirements file into the image
+COPY requirements.txt ./
 
-# Use PPM for binary installs
-ENV RENV_CONFIG_REPOS_OVERRIDE "https://packagemanager.posit.co/cran/__linux__/jammy/latest"
-ENV RENV_CONFIG_SANDBOX_ENABLED FALSE
-ENV RENV_PATHS_LIBRARY renv/library
-ENV RENV_PATHS_CACHE /setup/cache
-
-# Install system dependencies
-RUN apt-get update && \
-    apt-get install --no-install-recommends -y \
-        libcurl4-openssl-dev libssl-dev libxml2-dev libgit2-dev git \
-        libudunits2-dev python3-dev python3-pip python3-venv libgdal-dev \
-        libgeos-dev libproj-dev libfontconfig1-dev libharfbuzz-dev \
-        libfribidi-dev pandoc curl gdebi-core && \
-    rm -rf /var/lib/apt/lists/*
-
-# Install Quarto
-RUN curl -o quarto-linux-amd64.deb -L \
-    https://github.com/quarto-dev/quarto-cli/releases/download/v1.3.450/quarto-1.3.450-linux-amd64.deb
-RUN gdebi -n quarto-linux-amd64.deb
-
-# Install pipeline Python dependencies globally
-RUN pip install --no-cache-dir dvc[s3]
-
-# Copy R bootstrap files into the image
-COPY renv.lock .Rprofile DESCRIPTION requirements.txt ./
-COPY renv/profiles/reporting/renv.lock reporting-renv.lock
-COPY renv/ renv/
-
-# Install R dependencies. Restoring renv first ensures that it's
-# using the same version as recorded in the lockfile
-RUN Rscript -e 'renv::restore(packages = "renv"); renv::restore()'
-RUN Rscript -e 'renv::restore(lockfile = "reporting-renv.lock")'
+# Install Python requirements
+RUN pip install -U -r requirements.txt
 
 # Set the working directory to the model directory
 WORKDIR /model-res-avm/
@@ -43,10 +12,5 @@ WORKDIR /model-res-avm/
 # Copy the directory into the container
 COPY ./ .
 
-# Copy R dependencies into the model directory
-RUN rm -Rf /model-res-avm/renv && \
-    mv /setup/renv /model-res-avm/renv
-
-RUN pip install -U -r requirements.txt
-
+# Run comps algorithm
 CMD python3 python/comps.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/2.3.0-cuda12.1-cudnn8-runtime
+FROM pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime
 
 # Copy Python requirements file into the image
 COPY requirements.txt ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,6 @@ COPY ./ .
 RUN rm -Rf /model-res-avm/renv && \
     mv /setup/renv /model-res-avm/renv
 
+RUN pip install -U -r requirements.txt
+
 CMD python3 python/comps.py

--- a/python/comps.py
+++ b/python/comps.py
@@ -6,7 +6,7 @@ import pandas as pd
 import taichi as ti
 
 # Initialize taichi
-ti.init(arch=ti.gpu, default_ip=ti.i32, default_fp=ti.f32)
+ti.init(arch=ti.cpu, default_ip=ti.i32, default_fp=ti.f32)
 
 
 def get_comps(

--- a/python/comps.py
+++ b/python/comps.py
@@ -99,11 +99,11 @@ def get_comps(
     # that we can make use of fast loops
     observation_matrix = observation_df[["id", "predicted_value"]].values
     taichi_obs_ndarray = ti.ndarray(dtype=int, shape=observation_matrix.shape)
-    taichi_obs_ndarray.from_numpy(observation_matrix),
+    taichi_obs_ndarray.from_numpy(observation_matrix)
 
     price_bin_matrix = price_bin_indices.values
     taichi_bin_ndarray = ti.ndarray(dtype=int, shape=price_bin_matrix.shape)
-    taichi_bin_ndarray.from_numpy(price_bin_matrix),
+    taichi_bin_ndarray.from_numpy(price_bin_matrix)
 
     num_observations = observation_matrix.shape[0]
     num_price_bins = price_bin_matrix.shape[0]

--- a/python/comps.py
+++ b/python/comps.py
@@ -8,11 +8,6 @@ import taichi as ti
 # Initialize taichi
 ti.init(arch=ti.cpu, default_ip=ti.i32, default_fp=ti.f32)
 
-# Custom taichi types
-TopNComps = ti.types.struct()
-IntegerVector = ti.types.vector(1, int)
-Ndarray = ti.types.ndarray()
-
 
 def get_comps(
     observation_df,
@@ -104,19 +99,21 @@ def get_comps(
     # that we can make use of fast loops
     observation_matrix = observation_df[["id", "predicted_value"]].values
     taichi_obs_ndarray = ti.ndarray(dtype=int, shape=observation_matrix.shape)
+    taichi_obs_ndarray.from_numpy(observation_matrix),
 
     price_bin_matrix = price_bin_indices.values
     taichi_bin_ndarray = ti.ndarray(dtype=int, shape=price_bin_matrix.shape)
+    taichi_bin_ndarray.from_numpy(price_bin_matrix),
 
     num_observations = observation_matrix.shape[0]
     num_price_bins = price_bin_matrix.shape[0]
 
     # Output vector
-    binned_vector = IntegerVector.field(shape=num_observations)
+    binned_vector = ti.ndarray(dtype=int, shape=(num_observations, 1))
 
     _bin_by_price(
-        taichi_obs_ndarray.from_numpy(observation_matrix),
-        taichi_bin_ndarray.from_numpy(price_bin_matrix),
+        taichi_obs_ndarray,
+        taichi_bin_ndarray,
         binned_vector,
         num_observations,
         num_price_bins
@@ -178,14 +175,40 @@ def get_comps(
             flush=True
         )
 
-        comp_ids, comp_scores = _get_top_n_comps(
-            observation_matrix, possible_comp_matrix, weights_matrix, num_comps
+        num_observations = len(observation_matrix)
+        num_possible_comparisons = len(possible_comp_matrix)
+
+        # Store scores and indexes in two separate arrays rather than a 3d matrix
+        # for simplicity (array of tuples does not convert to pandas properly).
+        comp_ids =  ti.ndarray(dtype=int, shape=(num_observations, num_comps))
+        comp_scores =  ti.ndarray(dtype=float, shape=(num_observations, num_comps))
+
+        # Indexes default to -1, which is an impossible index and so is a signal
+        # that no comp was found
+        comp_ids.fill(-1)
+
+        num_trees = observation_matrix.shape[1]
+
+        _get_top_n_comps(
+            observation_matrix,
+            possible_comp_matrix,
+            weights_matrix,
+            comp_ids,
+            comp_scores,
+            num_comps,
+            num_observations,
+            num_possible_comparisons,
+            num_trees,
         )
 
         # Match comp and observation IDs back to the original dataframes since
         # we have since rearranged them
+        comp_ids = comp_ids.to_numpy()
+        comp_scores = comp_scores.to_numpy()
+
         matched_comp_ids = np.vectorize(comp_idx_to_id.get)(comp_ids)
         observation_ids = observations["id"].values
+
         for obs_idx, comp_idx, comp_score in zip(
             observation_ids, matched_comp_ids, comp_scores
         ):
@@ -223,9 +246,9 @@ def get_comps(
 
 @ti.kernel
 def _bin_by_price(
-    observation_matrix: Ndarray,
-    price_bin_matrix: Ndarray,
-    output_vector: IntegerVector,
+    observation_matrix: ti.types.ndarray(),
+    price_bin_matrix: ti.types.ndarray(),
+    output_vector: ti.types.ndarray(),
     num_observations: int,
     num_price_bins: int
 ):
@@ -249,14 +272,14 @@ def _bin_by_price(
                 # ranges can be treated as inclusive on both ends
                 observation_price >= bin_min and observation_price <= bin_max
             ):
-                output_vector[obs_idx] = bin_id
+                output_vector[obs_idx, 0] = bin_id
                 bin_found = True
                 break
 
         if not bin_found:
             # Set a special value to indicate an error, since taichi doesn't
             # support runtime errors
-            output_vector[obs_idx] = -1
+            output_vector[obs_idx, 0] = -1
 
 
 @ti.kernel
@@ -264,39 +287,26 @@ def _get_top_n_comps(
     leaf_node_matrix: ti.types.ndarray(),
     comparison_leaf_node_matrix: ti.types.ndarray(),
     weights_matrix: ti.types.ndarray(),
-    num_comps: int
-) -> TopNComps:
+    all_top_n_idxs: ti.types.ndarray(),
+    all_top_n_scores: ti.types.ndarray(),
+    num_comps: int,
+    num_observations: int,
+    num_possible_comparisons: int,
+    num_trees: int
+):
     """Helper function that takes matrices of leaf node assignments for
     observations in a tree model, a matrix of weights for each obs/tree, and an
     integer `num_comps`, and returns a matrix where each observation is scored
     by similarity to observations in the comparison matrix and the top N scores
     are returned along with the indexes of the comparison observations."""
-    num_observations = len(leaf_node_matrix)
-    num_possible_comparisons = len(comparison_leaf_node_matrix)
-    idx_dtype = np.int32
-    score_dtype = np.float32
-
-    # Store scores and indexes in two separate arrays rather than a 3d matrix
-    # for simplicity (array of tuples does not convert to pandas properly).
-    # Indexes default to -1, which is an impossible index and so is a signal
-    # that no comp was found
-    all_top_n_idxs = np.full((num_observations, num_comps), -1, dtype=idx_dtype)
-    all_top_n_scores = np.zeros((num_observations, num_comps), dtype=score_dtype)
-
     for x_i in range(num_observations):
-        top_n_idxs = np.full(num_comps, -1, dtype=idx_dtype)
-        top_n_scores = np.zeros(num_comps, dtype=score_dtype)
-
-        # TODO: We could probably speed this up by skipping comparisons we've
-        # already made; we just need to do it in a way that will have a
-        # low memory footprint
         for y_i in range(num_possible_comparisons):
             similarity_score = 0.0
-            for tree_idx in range(len(leaf_node_matrix[x_i])):
+            for tree_idx in range(num_trees):
                 similarity_score += (
-                    weights_matrix[x_i][tree_idx] * (
-                        leaf_node_matrix[x_i][tree_idx] ==
-                        comparison_leaf_node_matrix[y_i][tree_idx]
+                    weights_matrix[x_i, tree_idx] * (
+                        leaf_node_matrix[x_i, tree_idx] ==
+                        comparison_leaf_node_matrix[y_i, tree_idx]
                     )
                 )
 
@@ -304,30 +314,32 @@ def _get_top_n_comps(
             # comps, and store it in the sorted comps array if it is.
             # First check if the score is higher than the lowest score,
             # since otherwise we don't need to bother iterating the scores
-            if similarity_score > top_n_scores[-1]:
-              for idx, score in enumerate(top_n_scores):
-                if similarity_score > score:
-                  top_n_idxs = _insert_at_idx_and_shift(
-                    top_n_idxs, y_i, idx
-                  )
-                  top_n_scores = _insert_at_idx_and_shift(
-                    top_n_scores, similarity_score, idx
-                  )
-                  break
+            if similarity_score > all_top_n_scores[x_i, num_comps - 1]:
+              for idx in range(num_comps):
+                if similarity_score > all_top_n_scores[x_i, idx]:
+                    # Shift scores and indices to make room for the new one.
+                    # This requires iterating the indices backwards; since
+                    # taichi doesn't support the `step` parameter in `range()`
+                    # calls the way that Python does, we need to recreate
+                    # it with other primitives
+                    for i in range(num_comps - 1, idx):
+                        all_top_n_scores[x_i, i] = all_top_n_scores[x_i, i - 1]
+                        all_top_n_idxs[x_i, i] = all_top_n_idxs[x_i, i - 1]
 
-        all_top_n_idxs[x_i] = top_n_idxs
-        all_top_n_scores[x_i] = top_n_scores
-
-    return all_top_n_idxs, all_top_n_scores
+                    # Insert the new score and index at the correct position
+                    all_top_n_scores[x_i, idx] = similarity_score
+                    all_top_n_idxs[x_i, idx] = y_i
+                    break
 
 
 @ti.func
-def _insert_at_idx_and_shift(arr, elem, idx):
-  """Helper function to insert an element `elem` into a sorted numpy array `arr`
-  at a given index `idx` and shift the subsequent elements down one index."""
-  return np.concatenate((
-    arr[:idx], np.array([(elem)], dtype=arr.dtype), arr[idx:-1]
-  ))
+def _insert_at_coord_and_shift(ndarr, x, y, elem, max_len):
+    """Helper function to insert an element `elem` into a sorted numpy array `arr`
+    at a given (x, y) coordinate and shift the subsequent elements down one
+    index, with a maximum of `max_len` elements."""
+    for i in range(max_len - 1, y, -1):
+        ndarr[x, i] = ndarr[x, i - 1]
+    ndarr[x, y] = elem
 
 
 if __name__ == "__main__":

--- a/python/comps.py
+++ b/python/comps.py
@@ -348,8 +348,8 @@ if __name__ == "__main__":
     import time
 
     num_trees = 500
-    num_obs = 20001
-    num_comparisons = 10000
+    num_obs = 100000
+    num_comparisons = 50000
     mean_sale_price = 350000
     std_deviation = 110000
 

--- a/python/comps.py
+++ b/python/comps.py
@@ -6,7 +6,7 @@ import pandas as pd
 import taichi as ti
 
 # Initialize taichi
-ti.init(arch=ti.cpu, default_ip=ti.i32, default_fp=ti.f32)
+ti.init(arch=ti.gpu, default_ip=ti.i32, default_fp=ti.f32)
 
 
 def get_comps(

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-dateutil==2.8.2
 pytz==2023.3.post1
 six==1.16.0
 tzdata==2023.3
+taichi~=1.7.1


### PR DESCRIPTION
⚠️ **I don't plan to merge this PR, but am requesting review for the sake of knowledge transfer.** ⚠️ 

This PR tests out the use of [taichi](https://docs.taichi-lang.org/docs/hello_world) for the comps algorithm rather than numba.

Connects #229.

## Findings

See `Benchmarking` below for detailed stats comparing this approach to our existing code on different architectures. Some high-level takeaways: 

* CUDA doesn't seem to make much of a difference, and is counterproductive if anything. This makes me wonder whether the algorithm needs to be redesigned to make better use of the GPU (note that numba has [an entirely separate interface for CUDA programming](https://numba.pydata.org/numba-doc/latest/cuda/index.html)), but I'm considering that question out of scope for now.
* There are big performance gains to be had by simply bumping the instance type with the existing numba code. If the numbers below hold, we could speed up the comps code by 2x if we switched to c5.24xlarge instances, which are about twice as expensive as the m4.10xlarge instances we use now (meaning we should expect to break even on the change).
* At small scales (20k observations/10k comparisons), taichi appears to outperform numba, but this improvement disappears if we scale up the size of the data. At a large scale (100k observations/50k comparisons), they perform about the same.
* As evidenced by the code in this PR, the taichi interface is harder to work with than numba. Taichi is more strict about types, and doesn't support some basic operations that Python does (most notably, getting the shape of an array and returning an array from a function) making the code more confusing and un-Pythonic.

## Benchmarking

### 20k observations, 10k comparisons

| framework | instance type | arch | time | logs |
| --- | --- | --- | --- | --- |
| taichi | g5.12xlarge | x86 | 2.36s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-229-spike-upgrading-comps-algorithm-with-taichi_ccao-data-model-res-avm%2Fdefault%2F513c8edc94c34e4f957700d114e0ab67) |
| taichi | g5.12xlarge | CUDA | 4.33s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-229-spike-upgrading-comps-algorithm-with-taichi_ccao-data-model-res-avm%2Fdefault%2F7a5abb476b5b48ac9c9972b1ebf0bade) |
| taichi | m4.10xlarge | x86 | 4.44s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-229-spike-upgrading-comps-algorithm-with-taichi_ccao-data-model-res-avm%2Fdefault%2F605cd8ad040c46e19cf72321338a02bc) |
| numba | g5.12xlarge | x86 | 6.07s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-benchmark-comps-algorithm_ccao-data-model-res-avm%2Fdefault%2F49fec7a67af14e8e8f23396788c1d653) | 
| numba | m4.10xlarge | x86 | 10.52s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-benchmark-comps-algorithm_ccao-data-model-res-avm%2Fdefault%2F44ba304ca9514f2e8ff90d2a63b03e91) | 

### 100k observations, 50k comparisons

| framework | instance type | arch | time | logs |
| --- | --- | --- | --- | --- |
| numba | g5.12xlarge | x86 | 31.87s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-benchmark-comps-algorithm_ccao-data-model-res-avm%2Fdefault%2F018065ef265446d4a59c363d99b19d61) |
| taichi | c5.24xlarge | x86 | 31.93s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-229-spike-upgrading-comps-algorithm-with-taichi_ccao-data-model-res-avm%2Fdefault%2F4a338e53d524438d835da0438aaa0f34) |
| taichi | m4.10xlarge | x86 | 34.09s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-229-spike-upgrading-comps-algorithm-with-taichi_ccao-data-model-res-avm%2Fdefault%2F62e5297fc77949acb2b272a740c215dd) |
| numba | c5.24xlarge | x86 | 37.31s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-benchmark-comps-algorithm_ccao-data-model-res-avm%2Fdefault%2F8501cfb3e1344d10a217cd8de9755650) |
| taichi | g5.12xlarge | x86 | 37.75s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-229-spike-upgrading-comps-algorithm-with-taichi_ccao-data-model-res-avm%2Fdefault%2Fd31c9ed238cc4bf590e7ee757fd32200) |
| taichi | g5.12xlarge | CUDA | 43.58s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-229-spike-upgrading-comps-algorithm-with-taichi_ccao-data-model-res-avm%2Fdefault%2F47bf830f9ced430a8ec35de7586453a3) |
| numba | m4.10xlarge | x86 | 64.19s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-benchmark-comps-algorithm_ccao-data-model-res-avm%2Fdefault%2Fba0fc691f87e48c7a3a752c5bb9e7345) | 