### PR TITLE
Temporarily update Dockerfile to run python/comps.py

### DIFF
--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -72,7 +72,6 @@ jobs:
     uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@main
     with:
       backend: "ec2"
-      gpu: "4"
       vcpu: "40"
       memory: "158000"
       # Maximum pipeline runtime. This is slightly below 6 hours, which

--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -73,8 +73,8 @@ jobs:
     with:
       ref: jeancochrane/spike-c5-instances-for-build-and-run-batch-job
       backend: "ec2"
-      vcpu: "95"
-      memory: "190000"
+      vcpu: "90"
+      memory: "180000"
       # Maximum pipeline runtime. This is slightly below 6 hours, which
       # is the maximum length of any single GitHub Actions job
       role-duration-seconds: 21000

--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -72,6 +72,7 @@ jobs:
     uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@main
     with:
       backend: "ec2"
+      gpu: "4"
       vcpu: "40"
       memory: "158000"
       # Maximum pipeline runtime. This is slightly below 6 hours, which

--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -73,8 +73,8 @@ jobs:
     with:
       ref: jeancochrane/spike-c5-instances-for-build-and-run-batch-job
       backend: "ec2"
-      vcpu: "72"
-      memory: "144000"
+      vcpu: "95"
+      memory: "190000"
       # Maximum pipeline runtime. This is slightly below 6 hours, which
       # is the maximum length of any single GitHub Actions job
       role-duration-seconds: 21000

--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -69,12 +69,12 @@ jobs:
       # required in order to allow the reusable called workflow to push to
       # GitHub Container Registry
       packages: write
-    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@main
+    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@jeancochrane/spike-c5-instances-for-build-and-run-batch-job
     with:
+      ref: jeancochrane/spike-c5-instances-for-build-and-run-batch-job
       backend: "ec2"
-      gpu: "4"
-      vcpu: "40"
-      memory: "158000"
+      vcpu: "72"
+      memory: "144000"
       # Maximum pipeline runtime. This is slightly below 6 hours, which
       # is the maximum length of any single GitHub Actions job
       role-duration-seconds: 21000

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,6 @@ COPY ./ .
 RUN rm -Rf /model-res-avm/renv && \
     mv /setup/renv /model-res-avm/renv
 
-CMD dvc pull && dvc repro
+RUN pip install -U -r requirements.txt
+
+CMD python3 python/comps.py

--- a/python/comps.py
+++ b/python/comps.py
@@ -298,8 +298,8 @@ if __name__ == "__main__":
     import time
 
     num_trees = 500
-    num_obs = 20001
-    num_comparisons = 10000
+    num_obs = 100000
+    num_comparisons = 50000
     mean_sale_price = 350000
     std_deviation = 110000
 


### PR DESCRIPTION
This PR is a companion to https://github.com/ccao-data/model-res-avm/pull/236, intended to benchmark the current performance of the comps algorithm using numba. I don't plan to merge it and instead will close it once benchmarking is complete.

## Findings

* CUDA doesn't seem to make much of a difference, and is counterproductive if anything. This makes me wonder whether the algorithm needs to be redesigned to make better use of the GPU, but I'm considering that question out of scope for now.
* There are big performance gains to be had by simply bumping the instance type with the existing numba code. If the numbers below hold, we could speed up the comps code by 2x if we switched to c5.24xlarge instances, which are about twice as expensive as the m4.10xlarge instances we use now, so we'd probably break even on the change.
* At small scales (20k observations/10k comparisons), taichi appears to outperform numba, but this improvement disappears if we scale up the size of the data. At a large scale (100k observations/50k comparisons), they perform about the same.

## 20k observations, 10k comparisons

| framework | instance type | arch | time | logs |
| --- | --- | --- | --- | --- |
| taichi | g5.12xlarge | x86 | 2.36s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-229-spike-upgrading-comps-algorithm-with-taichi_ccao-data-model-res-avm%2Fdefault%2F513c8edc94c34e4f957700d114e0ab67) |
| taichi | g5.12xlarge | CUDA | 4.33s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-229-spike-upgrading-comps-algorithm-with-taichi_ccao-data-model-res-avm%2Fdefault%2F7a5abb476b5b48ac9c9972b1ebf0bade) |
| taichi | m4.10xlarge | x86 | 4.44s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-229-spike-upgrading-comps-algorithm-with-taichi_ccao-data-model-res-avm%2Fdefault%2F605cd8ad040c46e19cf72321338a02bc) |
| numba | g5.12xlarge | x86 | 6.07s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-benchmark-comps-algorithm_ccao-data-model-res-avm%2Fdefault%2F49fec7a67af14e8e8f23396788c1d653) | 
| numba | m4.10xlarge | x86 | 10.52s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-benchmark-comps-algorithm_ccao-data-model-res-avm%2Fdefault%2F44ba304ca9514f2e8ff90d2a63b03e91) | 

## 100k observations, 50k comparisons

| framework | instance type | arch | time | logs |
| --- | --- | --- | --- | --- |
| numba | g5.12xlarge | x86 | 31.87s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-benchmark-comps-algorithm_ccao-data-model-res-avm%2Fdefault%2F018065ef265446d4a59c363d99b19d61) |
| taichi | c5.24xlarge | x86 | 31.93s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-229-spike-upgrading-comps-algorithm-with-taichi_ccao-data-model-res-avm%2Fdefault%2F4a338e53d524438d835da0438aaa0f34) |
| taichi | m4.10xlarge | x86 | 34.09s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-229-spike-upgrading-comps-algorithm-with-taichi_ccao-data-model-res-avm%2Fdefault%2F62e5297fc77949acb2b272a740c215dd) |
| numba | c5.24xlarge | x86 | 37.31s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-benchmark-comps-algorithm_ccao-data-model-res-avm%2Fdefault%2F8501cfb3e1344d10a217cd8de9755650) |
| taichi | g5.12xlarge | x86 | 37.75s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-229-spike-upgrading-comps-algorithm-with-taichi_ccao-data-model-res-avm%2Fdefault%2Fd31c9ed238cc4bf590e7ee757fd32200) |
| taichi | g5.12xlarge | CUDA | 43.58s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-229-spike-upgrading-comps-algorithm-with-taichi_ccao-data-model-res-avm%2Fdefault%2F47bf830f9ced430a8ec35de7586453a3) |
| numba | m4.10xlarge | x86 | 64.19s | [link](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_jeancochrane-benchmark-comps-algorithm_ccao-data-model-res-avm%2Fdefault%2Fba0fc691f87e48c7a3a752c5bb9e7345) | 