### PR TITLE
Fix file permissions error in `style-files` pre-commit hook

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,4 +13,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run pre-commit checks
-        uses: ccao-data/actions/pre-commit@main
+        uses: ccao-data/actions/pre-commit@jeancochrane/time-pre-commit

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,4 +13,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run pre-commit checks
-        uses: ccao-data/actions/pre-commit@jeancochrane/time-pre-commit
+        uses: ccao-data/actions/pre-commit@main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
     hooks:
     -   id: style-files
         args: [--style_pkg=styler, --style_fun=tidyverse_style]
+        require_serial: true
     -   id: lintr
     -   id: readme-rmd-rendered
         exclude: reports/README.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,6 @@ repos:
     hooks:
     -   id: style-files
         args: [--style_pkg=styler, --style_fun=tidyverse_style]
-        require_serial: true
     -   id: lintr
     -   id: readme-rmd-rendered
         exclude: reports/README.md


### PR DESCRIPTION
This PR fixes the intermittent errors we see in the `style-files` hook of the `pre-commit` workflow by setting `require_serial` to `true` for the hook our pre-commit config. This config value prevents pre-commit from running in parallel, which is [the root cause of the error](https://github.com/lorenzwalthert/precommit/issues/571).

This change also has the nice side effect of decreasing the runtime of the hook. See [here](https://github.com/ccao-data/model-res-avm/actions/runs/9271984164/job/25508665127#step:3:116) for a workflow run that times `style-files` when run in parallel (real clock time 5.6s) and [here](https://github.com/ccao-data/model-res-avm/actions/runs/9271929136/job/25508589425#step:3:114) for a workflow run that times it when run serially (real clock time 2.4s). These timings are consistent with what I saw locally, so I think the numbers are solid. My guess is that we have few enough R files in the repo such that the overhead of forking the process outweighs the benefit of styling multiple files in parallel.