### PR TITLE
Adjust references to deprecated `sv_outlier_type`

### DIFF
--- a/pipeline/00-ingest.R
+++ b/pipeline/00-ingest.R
@@ -47,7 +47,9 @@ training_data <- dbGetQuery(
       sale.seller_name AS meta_sale_seller_name,
       sale.buyer_name AS meta_sale_buyer_name,
       sale.sv_is_outlier,
-      sale.sv_outlier_type,
+      sale.sv_outlier_reason1,
+      sale.sv_outlier_reason2,
+      sale.sv_outlier_reason3,
       sale.sv_run_id,
       res.*
   FROM model.vw_card_res_input res
@@ -332,8 +334,7 @@ training_data_clean <- training_data_w_hie %>%
   # Only exclude explicit outliers from training. Sales with missing validation
   # outcomes will be considered non-outliers
   mutate(
-    sv_is_outlier = replace_na(sv_is_outlier, FALSE),
-    sv_outlier_type = replace_na(sv_outlier_type, "Not outlier")
+    sv_is_outlier = replace_na(sv_is_outlier, FALSE)
   ) %>%
   mutate(
     # Miscellaneous column-level cleanup

--- a/pipeline/02-assess.R
+++ b/pipeline/02-assess.R
@@ -375,9 +375,11 @@ sales_data_two_most_recent <- sales_data %>%
   ) %>%
   # Include outliers, since these data are used for desk review and
   # not for modeling
-  rename(meta_sale_outlier_reason1 = sv_outlier_reason1,
-         meta_sale_outlier_reason2 = sv_outlier_reason2,
-         meta_sale_outlier_reason3 = sv_outlier_reason3) %>%
+  rename(
+    meta_sale_outlier_reason1 = sv_outlier_reason1,
+    meta_sale_outlier_reason2 = sv_outlier_reason2,
+    meta_sale_outlier_reason3 = sv_outlier_reason3
+  ) %>%
   mutate(
     meta_sale_outlier_type = ifelse(
       meta_sale_outlier_type == "Not outlier", NA, meta_sale_outlier_type

--- a/pipeline/02-assess.R
+++ b/pipeline/02-assess.R
@@ -371,7 +371,7 @@ sales_data_two_most_recent <- sales_data %>%
   distinct(
     meta_pin, meta_year,
     meta_sale_price, meta_sale_date, meta_sale_document_num,
-    sv_outlier_type
+    sv_outlier_reason1, sv_outlier_reason2, sv_outlier_reason3
   ) %>%
   # Include outliers, since these data are used for desk review and
   # not for modeling
@@ -379,11 +379,6 @@ sales_data_two_most_recent <- sales_data %>%
     meta_sale_outlier_reason1 = sv_outlier_reason1,
     meta_sale_outlier_reason2 = sv_outlier_reason2,
     meta_sale_outlier_reason3 = sv_outlier_reason3
-  ) %>%
-  mutate(
-    meta_sale_outlier_type = ifelse(
-      meta_sale_outlier_type == "Not outlier", NA, meta_sale_outlier_type
-    )
   ) %>%
   group_by(meta_pin) %>%
   slice_max(meta_sale_date, n = 2) %>%
@@ -395,7 +390,9 @@ sales_data_two_most_recent <- sales_data %>%
       meta_sale_date,
       meta_sale_price,
       meta_sale_document_num,
-      meta_sale_outlier_type
+      meta_sale_outlier_reason1,
+      meta_sale_outlier_reason2,
+      meta_sale_outlier_reason3
     ),
     names_glue = "{mr}_{gsub('meta_sale_', '', .value)}"
   ) %>%

--- a/pipeline/02-assess.R
+++ b/pipeline/02-assess.R
@@ -375,7 +375,9 @@ sales_data_two_most_recent <- sales_data %>%
   ) %>%
   # Include outliers, since these data are used for desk review and
   # not for modeling
-  rename(meta_sale_outlier_type = sv_outlier_type) %>%
+  rename(meta_sale_outlier_reason1 = sv_outlier_reason1,
+         meta_sale_outlier_reason2 = sv_outlier_reason2,
+         meta_sale_outlier_reason3 = sv_outlier_reason3) %>%
   mutate(
     meta_sale_outlier_type = ifelse(
       meta_sale_outlier_type == "Not outlier", NA, meta_sale_outlier_type

--- a/reports/pin/pin.qmd
+++ b/reports/pin/pin.qmd
@@ -13,6 +13,7 @@ format:
     embed-resources: true
     toc: true
     toc_float: true
+    fig-align: center
     fontsize: 12pt
 knitr:
   opts_chunk:

--- a/reports/pin/pin.qmd
+++ b/reports/pin/pin.qmd
@@ -13,7 +13,6 @@ format:
     embed-resources: true
     toc: true
     toc_float: true
-    fig-align: center
     fontsize: 12pt
 knitr:
   opts_chunk:
@@ -94,7 +93,9 @@ training_data %>%
     "Sale Date" = meta_sale_date,
     "Sale Price" = meta_sale_price,
     "Document Number" = meta_sale_document_num,
-    "Outlier Type" = sv_outlier_type
+    "Outlier Reason 1" = sv_outlier_reason1,
+    "Outlier Reason 2" = sv_outlier_reason2,
+    "Outlier Reason 3" = sv_outlier_reason3
   ) %>%
   mutate(`Sale Price` = as.numeric(`Sale Price`)) %>%
   mutate(`Sale Price` = scales::dollar(`Sale Price`)) %>%


### PR DESCRIPTION
 Because of our [new sales val spec](https://github.com/ccao-data/model-sales-val/pull/128), we need to edit references to the outdated `sv_outlier_type` column. 

We will also need to substantially rework a portion of our outlier reporting, issue made [here](https://github.com/ccao-data/model-res-avm/issues/247).