### PR TITLE
Add shap plots to new_feature_template

### DIFF
--- a/analyses/shap_processing.qmd
+++ b/analyses/shap_processing.qmd
@@ -1,0 +1,154 @@
+
+
+# SHAP
+
+The primary metric that the CCAO Data team uses to assess the importance of a feature is its SHAP value. SHAP values provide the amount of value each feature contributes to a parcel's predicted value. The SHAP value is calculated for each observation in the dataset, and the median SHAP value for a feature is used to determine the relative influence of that feature. The higher the median SHAP value, the more influential the feature is in the model.
+
+## Absolute Value Rank of SHAP Scores
+
+```{r}
+shap_predictors <- unlist(metadata_new$model_predictor_all_name)
+```
+
+The following table produces the median absolute SHAP value by township, and creates a grouped table. In total, there are `r length(shap_predictors)` indicators in the model. Thus, if the median SHAP is ranked 1, it is the most important feature in a township, while if it is ranked `r length(shap_predictors)`, it is the least important feature in a township. The median value (without absolute) is also included to better contextualize the impact.
+
+
+```{r shap_processing}
+# Combine data
+shap_df_filtered_long <- shap_new %>%
+  inner_join(
+    assessment_data_new %>%
+      select(meta_pin, meta_card_num, meta_township_code, meta_nbhd_code) %>%
+      rename(township_code = meta_township_code, neighborhood_code = meta_nbhd_code),
+    by = c("meta_pin", "meta_card_num")
+  ) %>%
+  select(township_code, all_of(shap_predictors)) %>%
+  pivot_longer(
+    cols = all_of(shap_predictors),
+    names_to = "feature",
+    values_to = "shap"
+  )
+```
+
+### SHAP Median Absolute Value
+```{r shap_full_importance}
+shap_df_filtered_long %>%
+  group_by(feature) %>%
+  mutate(
+    median_abs_shap = round(median(abs(shap), na.rm = TRUE), 2),
+    median_shap = round(median(shap, na.rm = TRUE), 2)
+  ) %>%
+  ungroup() %>%
+  distinct(feature, .keep_all = TRUE) %>%
+  arrange(desc(median_abs_shap)) %>%
+  mutate(
+    rank_absolute = row_number(),
+    `Median Absolute Shap` = scales::dollar(median_abs_shap),
+    `Median SHAP` = scales::dollar(median_shap)
+  ) %>%
+  inner_join(ccao::town_dict, by = c("township_code" = "township_code")) %>%
+  ccao::vars_rename(
+    names_from = "model",
+    names_to = "pretty",
+    type = "inplace",
+    dict = ccao::vars_dict
+  ) %>%
+  clean_column_values("feature") %>%
+  select(
+    Feature = feature, 
+    'Median Absolute Shap', 
+    'Median SHAP', 
+    'Rank Absolute' = rank_absolute
+  ) %>%
+  datatable(
+    options = list(
+      scrollY = "300px",
+      scrollX = TRUE,
+      paging = FALSE,
+      searching = TRUE
+    ),
+    rownames = FALSE
+  )
+
+```
+
+### SHAP Median Absolute Value by Township
+```{r shap_township_importance}
+shap_df_filtered_long %>%
+  group_by(township_code, feature) %>%
+  mutate(
+    median_abs_shap = round(median(abs(shap), na.rm = TRUE), 2),
+    median_shap = round(median(shap, na.rm = TRUE), 2)
+  ) %>%
+  ungroup() %>%
+  distinct(township_code, feature, .keep_all = TRUE) %>%
+  group_by(township_code) %>%
+  arrange(desc(median_abs_shap), .by_group = TRUE) %>%
+  mutate(
+    township_rank_absolute = row_number(),
+    `Median Absolute Shap` = scales::dollar(median_abs_shap),
+    `Median SHAP` = scales::dollar(median_shap)
+  ) %>%
+  ungroup() %>%
+  inner_join(ccao::town_dict, by = c("township_code" = "township_code")) %>%
+  ccao::vars_rename(
+    names_from = "model",
+    names_to = "pretty",
+    type = "inplace",
+    dict = ccao::vars_dict
+  ) %>%
+  clean_column_values("feature") %>%
+  select(
+    Township = township_name, 
+    `Township Code` = township_code, 
+    Feature = feature, 
+    `Median Absolute Shap`, 
+    `Median SHAP`, 
+    `Township Rank Absolute` = township_rank_absolute
+  ) %>%
+  datatable(
+    options = list(
+      scrollY = "300px",
+      scrollX = TRUE,
+      paging = FALSE,
+      searching = TRUE
+    ),
+    rownames = FALSE
+  )
+
+
+
+```
+
+
+```{r violin_plots_shap_to_feature}
+# Calculate the number of digits
+num_digits <- card_individual %>%
+  pull(!!sym(target_feature_shap)) %>%
+  max(na.rm = TRUE) %>%
+  floor() %>%
+  as.character() %>%
+  str_length()
+
+quantiles <- card_individual %>%
+  pull(!!sym(target_feature_shap)) %>%
+  quantile(c(0.025, 0.975), na.rm = TRUE)
+
+# Create the violin plot, excluding outliers only in the display
+card_individual %>%
+  select(meta_card_num, meta_pin, !!sym(target_feature_shap), !!sym(target_feature_value)) %>%
+  mutate(bin = cut_number(!!sym(target_feature_value), n = 10, dig.lab = num_digits)) %>%
+  ggplot(aes(x = bin, y = !!sym(target_feature_shap))) +
+  geom_violin(fill = "#69b3a2") +
+  theme_minimal() +
+  xlab("Feature Value") +
+  ylab("SHAP Value") +
+  scale_x_discrete(labels = function(x) {
+    x <- gsub("\\.[^,\\]]*", "", x) # Clean the factor levels for chart
+    x <- gsub("[^0-9,,]", "", x)
+    gsub(",", "-", x)
+  }) +
+  coord_cartesian(ylim = quantiles) +  # Focus only on the range between the 2.5% and 97.5% quantiles
+  theme(axis.text.x = element_text(angle = 90, vjust = 0.5, hjust = 1))
+```
+

--- a/analyses/shap_processing.qmd
+++ b/analyses/shap_processing.qmd
@@ -148,3 +148,18 @@ card_individual %>%
   theme(axis.text.x = element_text(angle = 90, vjust = 0.5, hjust = 1))
 ```
 
+### Scatterplot Demonstrating the Relationship between SHAP and Feature Value
+
+```{r}
+shapviz::shapviz(
+  object = shap_new %>%
+    select(all_of(shap_predictors)) %>%
+    as.matrix(),
+  X = assessment_card_new %>%
+    select(all_of(shap_predictors)),
+  baseline = shap_new$pred_card_shap_baseline_fmv[1]
+) %>%
+  shapviz::sv_dependence(
+    v = target_feature_value
+    )
+```

--- a/analyses/shap_processing.qmd
+++ b/analyses/shap_processing.qmd
@@ -120,19 +120,19 @@ shap_df_filtered_long %>%
 ```{r violin_plots_shap_to_feature}
 # Calculate the number of digits
 num_digits <- card_individual %>%
-  pull(!!sym(target_feature_shap)) %>%
+  pull({{target_feature_shap}}) %>%
   max(na.rm = TRUE) %>%
   floor() %>%
   as.character() %>%
   str_length()
 
 quantiles <- card_individual %>%
-  pull(!!sym(target_feature_shap)) %>%
+  pull({{target_feature_shap}}) %>%
   quantile(c(0.025, 0.975), na.rm = TRUE)
 
 # Create the violin plot, excluding outliers only in the display
 card_individual %>%
-  select(meta_card_num, meta_pin, !!sym(target_feature_shap), !!sym(target_feature_value)) %>%
+  select(meta_card_num, meta_pin, {{target_feature_shap}}, {{target_feature_value}}) %>%
   mutate(bin = cut_number(!!sym(target_feature_value), n = 10, dig.lab = num_digits)) %>%
   ggplot(aes(x = bin, y = !!sym(target_feature_shap))) +
   geom_violin(fill = "#69b3a2") +

--- a/analyses/shap_processing.qmd
+++ b/analyses/shap_processing.qmd
@@ -120,19 +120,19 @@ shap_df_filtered_long %>%
 ```{r violin_plots_shap_to_feature}
 # Calculate the number of digits
 num_digits <- card_individual %>%
-  pull({{target_feature_shap}}) %>%
+  pull({{ target_feature_shap }}) %>%
   max(na.rm = TRUE) %>%
   floor() %>%
   as.character() %>%
   str_length()
 
 quantiles <- card_individual %>%
-  pull({{target_feature_shap}}) %>%
+  pull({{ target_feature_shap }}) %>%
   quantile(c(0.025, 0.975), na.rm = TRUE)
 
 # Create the violin plot, excluding outliers only in the display
 card_individual %>%
-  select(meta_card_num, meta_pin, {{target_feature_shap}}, {{target_feature_value}}) %>%
+  select(meta_card_num, meta_pin, {{ target_feature_shap }}, {{ target_feature_value }}) %>%
   mutate(bin = cut_number(!!sym(target_feature_value), n = 10, dig.lab = num_digits)) %>%
   ggplot(aes(x = bin, y = !!sym(target_feature_shap))) +
   geom_violin(fill = "#69b3a2") +

--- a/analyses/shap_processing.qmd
+++ b/analyses/shap_processing.qmd
@@ -55,10 +55,10 @@ shap_df_filtered_long %>%
   ) %>%
   clean_column_values("feature") %>%
   select(
-    Feature = feature, 
-    'Median Absolute Shap', 
-    'Median SHAP', 
-    'Rank Absolute' = rank_absolute
+    Feature = feature,
+    "Median Absolute Shap",
+    "Median SHAP",
+    "Rank Absolute" = rank_absolute
   ) %>%
   datatable(
     options = list(
@@ -69,7 +69,6 @@ shap_df_filtered_long %>%
     ),
     rownames = FALSE
   )
-
 ```
 
 ### SHAP Median Absolute Value by Township
@@ -99,11 +98,11 @@ shap_df_filtered_long %>%
   ) %>%
   clean_column_values("feature") %>%
   select(
-    Township = township_name, 
-    `Township Code` = township_code, 
-    Feature = feature, 
-    `Median Absolute Shap`, 
-    `Median SHAP`, 
+    Township = township_name,
+    `Township Code` = township_code,
+    Feature = feature,
+    `Median Absolute Shap`,
+    `Median SHAP`,
     `Township Rank Absolute` = township_rank_absolute
   ) %>%
   datatable(
@@ -115,9 +114,6 @@ shap_df_filtered_long %>%
     ),
     rownames = FALSE
   )
-
-
-
 ```
 
 
@@ -148,7 +144,7 @@ card_individual %>%
     x <- gsub("[^0-9,,]", "", x)
     gsub(",", "-", x)
   }) +
-  coord_cartesian(ylim = quantiles) +  # Focus only on the range between the 2.5% and 97.5% quantiles
+  coord_cartesian(ylim = quantiles) + # Focus only on the range between the 2.5% and 97.5% quantiles
   theme(axis.text.x = element_text(angle = 90, vjust = 0.5, hjust = 1))
 ```
 

--- a/analyses/shap_processing.qmd
+++ b/analyses/shap_processing.qmd
@@ -161,5 +161,5 @@ shapviz::shapviz(
 ) %>%
   shapviz::sv_dependence(
     v = target_feature_value
-    )
+  )
 ```


### PR DESCRIPTION
This modifies the previous SHAP plots to create a single table for all township-level SHAP values, rather than the previous version of producing tables for each township. It also uses the variable:dict to clean the SHAP names. It also modifies the previous box-plot to a violin plot for easier readability.

Other SHAP additions will go into a separate pull request.
#250 