### PR TITLE
Fix instructions for re-activating default renv profile in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -859,7 +859,7 @@ The process for updating *dependencies for other lockfiles** is more complex, si
 2. Make sure that the dependency is defined in the `DESCRIPTION` file under the `Config/renv/profiles/<profile_name>/dependencies` key
 3. Run `renv::install("<dependency_name>")` to add or update the dependency as necessary
 4. Run `renv::snapshot()` to update the reporting lockfile with the dependencies defined in the `DESCRIPTION` file
-5. Run `renv::activate()` if you would like to switch back to the default renv profile
+5. Run `renv::activate(profile = "default")` if you would like to switch back to the default renv profile
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -1465,8 +1465,8 @@ commands:
     dependency as necessary
 4.  Run `renv::snapshot()` to update the reporting lockfile with the
     dependencies defined in the `DESCRIPTION` file
-5.  Run `renv::activate()` if you would like to switch back to the
-    default renv profile
+5.  Run `renv::activate(profile = "default")` if you would like to switch
+    back to the default renv profile
 
 ## Troubleshooting
 


### PR DESCRIPTION
This PR implements a tiny fix to the README to reflect the correct way of reactivating the default profile in renv. Per [the docs](https://rstudio.github.io/renv/reference/activate.html#arg-profile):

> **profile**
>
> The profile to be activated. See [`vignette("profiles", package = "renv")`](https://rstudio.github.io/renv/articles/profiles.html) for more information. When `NULL` (the default), the profile is not changed. **Use `profile = "default"` to revert to the default renv profile.**

Note that I can't for the life of me figure out how to get RStudio to use the correct profile for knitting purposes (it always seems to want to install dependencies that are already installed, and then fails to do so properly) so I just went ahead and edited `README.md` directly since this is such a tiny change. Maybe someday this week we can do a troubleshooting question so I can learn how it's supposed to work.