### PR TITLE
Update 2023 data with sales val columns, remove site rate data

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -5,8 +5,8 @@ stages:
     deps:
     - path: pipeline/00-ingest.R
       hash: md5
-      md5: c04f9224e873b1ee29a64fa68aa6c8d9
-      size: 23355
+      md5: c453195da12dd0197e0bdd16f4ef3937
+      size: 23004
     params:
       params.yaml:
         assessment:
@@ -38,31 +38,28 @@ stages:
     outs:
     - path: input/assessment_data.parquet
       hash: md5
-      md5: c5c5b10a62f815a8b47de9101424dea6
-      size: 309845333
+      md5: e4b429a0121c6898b972fa20b42544fd
+      size: 425747228
     - path: input/char_data.parquet
       hash: md5
-      md5: 95b41b06f03b055c8f1ba77bf80c8d30
-      size: 616908148
+      md5: 827c97f9d3bbd3426e8f6fd9136313f8
+      size: 847441146
     - path: input/complex_id_data.parquet
       hash: md5
-      md5: d0b2c6cb1dbf8ae90de2ccee2e99568d
-      size: 702334
+      md5: 0e2a42a935106a9b6f50d8250012d98c
+      size: 703255
     - path: input/hie_data.parquet
       hash: md5
-      md5: 675edaaee68b015e15a9d753a3531124
-      size: 1924257
+      md5: ca86d0e5f29fd252455dc67e2dd40ac1
+      size: 1927927
     - path: input/land_nbhd_rate_data.parquet
       hash: md5
-      md5: e508daf5790982c303d6503fe1cb8e2b
-      size: 4413
-    - path: input/land_site_rate_data.parquet
-      md5: 7c6d3de25d8ec0d523e2ffd8f7b4e542
-      size: 2109
+      md5: f3ec9627322bd271bf2957b7388aaa34
+      size: 3873
     - path: input/training_data.parquet
       hash: md5
-      md5: 787d2c901d1d957b87ecaee83663e8e5
-      size: 163303649
+      md5: 76d91858f84f57ad2dce9fd292fe1ae2
+      size: 208138341
   train:
     cmd: Rscript pipeline/01-train.R
     deps:

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -17,6 +17,7 @@ stages:
     - input/land_nbhd_rate_data.parquet
     - input/training_data.parquet
 
+    frozen: true
   train:
     cmd: Rscript pipeline/01-train.R
     desc: >

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -15,10 +15,8 @@ stages:
     - input/complex_id_data.parquet
     - input/hie_data.parquet
     - input/land_nbhd_rate_data.parquet
-    - input/land_site_rate_data.parquet
     - input/training_data.parquet
 
-    frozen: true
   train:
     cmd: Rscript pipeline/01-train.R
     desc: >

--- a/pipeline/00-ingest.R
+++ b/pipeline/00-ingest.R
@@ -107,17 +107,8 @@ assessment_data %>%
 assessment_data <- assessment_data %>%
   filter(year == params$assessment$data_year)
 
-# Pull site-specific (pre-determined) land values and neighborhood-level land
-# rates ($/sqft), as calculated by Valuations
+# Pull neighborhood-level land rates ($/sqft), as calculated by Valuations
 tictoc::tic("Land rate data pulled")
-land_site_rate_data <- dbGetQuery(
-  conn = AWS_ATHENA_CONN_NOCTUA, glue("
-  SELECT *
-  FROM ccao.land_site_rate
-  WHERE year = '{params$assessment$year}'
-  ")
-)
-
 land_nbhd_rate_data <- dbGetQuery(
   conn = AWS_ATHENA_CONN_NOCTUA, glue("
   SELECT *
@@ -610,9 +601,6 @@ complex_id_data <- assessment_data_clean %>%
 message("Saving land rates")
 
 # Write land data directly to file, since it's already mostly clean
-land_site_rate_data %>%
-  select(meta_pin = pin, meta_class = class, land_rate_per_pin, year) %>%
-  write_parquet(paths$input$land_site_rate$local)
 land_nbhd_rate_data %>%
   select(meta_nbhd = town_nbhd, meta_class = class, land_rate_per_sqft) %>%
   write_parquet(paths$input$land_nbhd_rate$local)


### PR DESCRIPTION
This PR adds a set of updated 2023 input data. It:

- Removes the `land_site_rate` input, which is now deprecated
- Adds updated sales validation reason columns
