### PR TITLE
Fix Quarto plot error

### DIFF
--- a/reports/performance/_model.qmd
+++ b/reports/performance/_model.qmd
@@ -398,7 +398,10 @@ generate_model_ratio_township_graph <- function(data, township, lims) {
       lims$min_value,
       lims$max_value + 0.08
     )) +
-    scale_x_continuous(breaks = 1:10, labels = data_to_plot_labels) +
+    scale_x_continuous(
+      breaks = seq_along(data_to_plot_labels),
+      labels = data_to_plot_labels
+    ) +
     scale_color_manual(
       values = c(
         "Main Model" = plot_colors$main,


### PR DESCRIPTION
Fixes a tiny issue in Quarto in which townships with a lower-than-expected number of quantiles break their ratio curve plot. The lowered number of quantiles only occurs during testing (due to reduced sample size), but fixing this will make the code more robust.