### PR TITLE
Consider assessment year branches to be main branches in GitHub workflows

### DIFF
--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -51,7 +51,7 @@ on:
         default: false
         required: true
   push:
-    branches: [master]
+    branches: [master, "*-assessment-year"]
 
 jobs:
   build-and-run-model:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,7 +1,7 @@
 on:
   pull_request:
   push:
-    branches: [main, master]
+    branches: [main, master, "*-assessment-year"]
 
 name: pre-commit
 


### PR DESCRIPTION
I noticed while testing https://github.com/ccao-data/actions/pull/35 that our pre-commit checks aren't running on merge to the `2025-assessment-year` branch because our GitHub workflow configs don't consider this to be a main branch. This PR fixes that problem for 2025 and any future long-lived assessment year branches.