### PR TITLE
Add default land value

### DIFF
--- a/pipeline/02-assess.R
+++ b/pipeline/02-assess.R
@@ -175,6 +175,17 @@ assessment_pin_data_w_land <- assessment_card_data_round %>%
         pred_pin_final_fmv_round_no_prorate * params$pv$land_pct_of_total_cap,
       TRUE ~ char_land_sf * land_rate_per_sqft
     )),
+    # If the land $/sqft is missing, just use the max capped land value as a
+    # default (usually 50% of the predicted value). Data doesn't usually get
+    # land $/sqft until the beginning of the year we're modeling for, but a
+    # predicted land value is required to calculate the final estimated FMV. As
+    # such, setting this default lets us start modeling before we receive the
+    # finalized land $/sqft rates
+    pred_pin_final_fmv_land = ifelse(
+      is.na(pred_pin_final_fmv_land),
+      pred_pin_final_fmv_round_no_prorate * params$pv$land_pct_of_total_cap,
+      pred_pin_final_fmv_land
+    ),
     # Keep the uncapped value for display in desk review
     pred_pin_uncapped_fmv_land = ceiling(char_land_sf * land_rate_per_sqft)
   )


### PR DESCRIPTION
Our residential model runs started to fail after we switched the model to target Jan 1, 2024 for the _**North triad**_. They're failing because we don't have 2024 land $/sqft rates for the 2024 North tri, only for the city, since that's the triad that was assessed in 2024.

Land rates are required to calculate *final* (though not initial) residential estimates due to the interaction of the land % of FMV cap and proration rates. Without final estimates, the `03-evaluate` stage fails, since there are no non-null inputs to any of the aggregation functions.

This PR adds a _default_ land FMV value in the absence of a land $/sqft rate. The default value is 50% of the initial predicted value of the PIN/card. Adding a default value lets us estimate final values for triads where we don't have land rates (i.e. we can work ahead of when Valuations provides us rates).

FYI for @ccao-data/core-team and @ccao-data/juniors, since this is a pretty important change.