### PR TITLE
Upgrade Python dependencies for comps pipeline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-llvmlite==0.41.1
-numba==0.58.1
-numpy==1.26.2
-pandas==2.1.4
-python-dateutil==2.8.2
-pytz==2023.3.post1
-six==1.16.0
-tzdata==2023.3
+llvmlite==0.43.0
+numba==0.60.0
+numpy==2.0.2
+pandas==2.2.3
+python-dateutil==2.9.0.post0
+pytz==2024.2
+six==1.17.0
+tzdata==2024.2


### PR DESCRIPTION
Builds have [begun to fail](https://github.com/ccao-data/model-res-avm/actions/runs/12505966749/job/34890165762) due to version conflicts between our comps pipeline and the Python version that now comes preinstalled on GitHub runners. This PR updates the Python dependencies for the comps pipeline with the goal of eliminating these conflicts.

Install new dependencies and run `python3 python/comps.py` to run the test comps pipeline and confirm that the Python script still works as expected.

It would be nice if we could use uv and pyproject.toml for these dependencies like we're doing in all of our other Python projects now, but I can't find anything indicating that reticulate has (or is working on) uv support, and the pyproject support [seems specific to poetry](https://github.com/rstudio/reticulate/issues/1031).