### PR TITLE
Unset the random seed for run ID generation

### DIFF
--- a/pipeline/05-finalize.R
+++ b/pipeline/05-finalize.R
@@ -12,6 +12,8 @@ tictoc::tic("Finalize")
 # Load libraries, helpers, and recipes from files
 purrr::walk(list.files("R/", "\\.R$", full.names = TRUE), source)
 
+# Unset the seed from setup.R to ensure a random run ID
+set.seed(NULL)
 
 
 


### PR DESCRIPTION
We set a global seed in #307 to ensure reproducibility. However, this seed is also set when producing a random run ID, meaning we get the same run ID each time. This simply re-initializes the seed using the default R behavior.