### PR TITLE
Update Quarto docs and fix render bug

### DIFF
--- a/params.yaml
+++ b/params.yaml
@@ -429,4 +429,4 @@ comp:
 # upload
 export:
   triad_code: "1"
-  run_id: "2024-03-17-stupefied-maya"
+  run_id: "2025-01-10-serene-boni"

--- a/reports/README.md
+++ b/reports/README.md
@@ -5,13 +5,11 @@
 This directory contains Quarto diagnostic documents for the residential model. These documents are built and saved automatically for each model run. They are intended to help refine, examine, and diagnose *individual models*. Cross-model comparison is performed via separate Tableau dashboards. The two document types currently available are:
 
 1. `performance.qmd` - Overall look at model performance containing ratio statistics, diagnostic visualizations, debugging/quality control tables, etc.
-2. `pin.qmd` - Detailed diagnostic document for a *single* PIN
+2. `challenge_groups.qmd` - Report on specific, hard-to-model properties such as prorated PINs, multi-card properties, etc.
 
 ## Structure
 
-The documents in this directory are **modularized** and separated by topic area. Documents prefixed with an underscore are considered **modules** and can be interpolated into other documents using the Quarto [include shortcode](https://quarto.org/docs/authoring/includes.html).
-
-For example, `performance/_sales.qmd` builds only plots and tables related to the input sales data. It uses the shortcode `{{< include ../_setup.qmd >}}` on the first line to run `_setup.qmd`, which loads all necessary libraries and data dependencies.
+The documents in this directory are **modularized** and separated by topic area. Documents prefixed with an underscore are considered **modules** and can be interpolated into other documents using the Quarto [include shortcode](https://quarto.org/docs/authoring/includes.html). For example, `performance/_sales.qmd` builds only plots and tables related to the input sales data.
 
 Main documents do not have an underscore prefix. They combine metadata with multiple modules to generate a single, large report. For example, `performance/performance.qmd` combines modules and renders to a single HTML document with a table of contents.
 
@@ -26,6 +24,6 @@ Be sure to load any new data you used in the module in `_setup.qmd`, and add any
 
 ### Adding a New Module
 
-To add a new module, create a new Quarto document and prefix its filename with an underscore. Be sure to include the setup shortcode (`{{< include ../_setup.qmd >}}`) on the first line of the new file.
+To add a new module, create a new Quarto document and prefix its filename with an underscore. Be sure to call the setup script in a chunk at the beginning of the file. This script loads all data, initializes some useful objects, and generally sets up the document environment.
 
 Once your module is finalized, check that it renders independently using the **Render** button at the top of the document. If it succeeds, include it in a main document using an [include shortcode](https://quarto.org/docs/authoring/includes.html).

--- a/reports/_setup.R
+++ b/reports/_setup.R
@@ -1,12 +1,3 @@
----
-execute:
-  echo: false
-params:
-  run_id: "2024-03-17-stupefied-maya"
-  year: "2024"
----
-
-```{r}
 # This setup script is run at the top of each Quarto report subsection to load
 # libraries, data, and other objects needed for the report. It only loads
 # objects if they don't already exist in the environment, so it can be run
@@ -187,9 +178,7 @@ plot_colors <- list(
 shorten_number <- function(x) {
   scales::dollar(x, accuracy = 1, scale = 1 / 1000, suffix = "K")
 }
-```
 
-```{r}
 # Chunk to populate the metadata / dataset summaries in the text of each module
 # Anything prefixed with m_ is a variable that will be used directly in the text
 m_test_min_date <- min(test_card$meta_sale_date)
@@ -248,4 +237,3 @@ m_assess_stage_near <- paste(
   metadata$ratio_study_near_year,
   metadata$ratio_study_near_stage
 )
-```

--- a/reports/_setup.R
+++ b/reports/_setup.R
@@ -130,12 +130,14 @@ if (!exists("model_performance_test_linear")) {
     arrow::read_parquet(paths$output$performance_test_linear$local)
 }
 if (!exists("model_performance_quantile_test")) {
+  # nolint start: object_length_linter
   model_performance_quantile_test <-
     arrow::read_parquet(paths$output$performance_quantile_test$local)
 }
 if (!exists("model_performance_quantile_test_linear")) {
   model_performance_quantile_test_linear <-
     arrow::read_parquet(paths$output$performance_quantile_test_linear$local)
+  # nolint end
 }
 if (!exists("model_performance_assessment")) {
   model_performance_assessment <-
@@ -150,7 +152,7 @@ if (!exists("feat_imp_df")) {
 }
 
 # Load SHAP data if it exists (only exists for important runs)
-if (file.exists(paths$output$shap$local) & metadata$shap_enable) {
+if (file.exists(paths$output$shap$local) && metadata$shap_enable) {
   shap_df <- read_parquet(paths$output$shap$local)
   shap_exists <- nrow(shap_df) > 0
 } else {
@@ -158,7 +160,7 @@ if (file.exists(paths$output$shap$local) & metadata$shap_enable) {
 }
 
 # Load comp data if it exists
-if (file.exists(paths$output$comp$local) & metadata$comp_enable) {
+if (file.exists(paths$output$comp$local) && metadata$comp_enable) {
   comp_df <- read_parquet(paths$output$comp$local)
   comp_exists <- nrow(comp_df) > 0
 } else {
@@ -190,14 +192,18 @@ m_test_n_sales_triad <- test_card %>%
   filter(meta_triad_code == run_triad_code) %>%
   nrow() %>%
   scales::comma()
-m_test_n_sales_prop <-
-  (nrow(filter(test_card, meta_triad_code == run_triad_code)) /
-    nrow(test_card)) %>%
+m_test_n_sales_prop <- (
+  nrow(filter(test_card, meta_triad_code == run_triad_code)) /
+    nrow(test_card)
+) %>%
   scales::percent(accuracy = 0.01)
 m_test_med_sp <- test_card$meta_sale_price %>%
   median() %>%
   scales::dollar()
-m_test_split_prop <- scales::percent(1 - metadata$cv_split_prop, accuracy = 0.01)
+m_test_split_prop <- scales::percent(
+  1 - metadata$cv_split_prop,
+  accuracy = 0.01
+)
 
 m_train_min_date <- min(training_data$meta_sale_date)
 m_train_max_date <- max(training_data$meta_sale_date)
@@ -208,9 +214,10 @@ m_train_n_sales_triad <- training_data %>%
   filter(meta_triad_code == run_triad_code) %>%
   nrow() %>%
   scales::comma()
-m_train_n_sales_prop <-
-  (nrow(filter(training_data, meta_triad_code == run_triad_code)) /
-    nrow(training_data)) %>%
+m_train_n_sales_prop <- (
+  nrow(filter(training_data, meta_triad_code == run_triad_code)) /
+    nrow(training_data)
+) %>%
   scales::percent(accuracy = 0.01)
 m_train_med_sp <- training_data$meta_sale_price %>%
   median() %>%

--- a/reports/challenge_groups/challenge_groups.qmd
+++ b/reports/challenge_groups/challenge_groups.qmd
@@ -20,8 +20,8 @@ knitr:
     out.width: "100%"
 editor: source
 params:
-  run_id: "2024-03-17-stupefied-maya"
-  year: "2024"
+  run_id: "2025-01-10-serene-boni"
+  year: "2025"
 ---
 
 {{< include ../_setup.qmd >}}

--- a/reports/challenge_groups/challenge_groups.qmd
+++ b/reports/challenge_groups/challenge_groups.qmd
@@ -24,7 +24,9 @@ params:
   year: "2025"
 ---
 
-{{< include ../_setup.qmd >}}
+```{r _setup_script}
+source("../_setup.R")
+```
 
 ---
 

--- a/reports/performance/_comp.qmd
+++ b/reports/performance/_comp.qmd
@@ -1,4 +1,6 @@
-{{< include ../_setup.qmd >}}
+```{r _comp_setup_script}
+source("../_setup.R")
+```
 
 # Comparables
 

--- a/reports/performance/_input.qmd
+++ b/reports/performance/_input.qmd
@@ -1,4 +1,6 @@
-{{< include ../_setup.qmd >}}
+```{r _input_setup_script}
+source("../_setup.R")
+```
 
 # Data and Processing
 

--- a/reports/performance/_model.qmd
+++ b/reports/performance/_model.qmd
@@ -1,4 +1,6 @@
-{{< include ../_setup.qmd >}}
+```{r _model_setup_script}
+source("../_setup.R")
+```
 
 # Model
 

--- a/reports/performance/_outcomes.qmd
+++ b/reports/performance/_outcomes.qmd
@@ -1,4 +1,6 @@
-{{< include ../_setup.qmd >}}
+```{r _outcomes_setup_script}
+source("../_setup.R")
+```
 
 # Outcomes
 

--- a/reports/performance/_outliers.qmd
+++ b/reports/performance/_outliers.qmd
@@ -1,4 +1,6 @@
-{{< include ../_setup.qmd >}}
+```{r _outliers_setup_script}
+source("../_setup.R")
+```
 
 # Outliers
 

--- a/reports/performance/_sales.qmd
+++ b/reports/performance/_sales.qmd
@@ -1,4 +1,6 @@
-{{< include ../_setup.qmd >}}
+```{r _sales_setup_script}
+source("../_setup.R")
+```
 
 # Sales
 

--- a/reports/performance/_shap.qmd
+++ b/reports/performance/_shap.qmd
@@ -1,4 +1,6 @@
-{{< include ../_setup.qmd >}}
+```{r _shap_setup_script}
+source("../_setup.R")
+```
 
 # SHAP Values
 

--- a/reports/performance/_stats.qmd
+++ b/reports/performance/_stats.qmd
@@ -1,4 +1,6 @@
-{{< include ../_setup.qmd >}}
+```{r _stats_setup_script}
+source("../_setup.R")
+```
 
 # Statistical Tests
 

--- a/reports/performance/performance.qmd
+++ b/reports/performance/performance.qmd
@@ -20,11 +20,13 @@ knitr:
     out.width: "100%"
 editor: source
 params:
-  run_id: "2024-03-17-stupefied-maya"
-  year: "2024"
+  run_id: "2025-01-10-serene-boni"
+  year: "2025"
 ---
 
-{{< include ../_setup.qmd >}}
+```{r _setup}
+source("../_setup.R")
+```
 
 {{< include _model.qmd >}}
 
@@ -36,7 +38,7 @@ params:
 
 {{< include _input.qmd >}}
 
-```{r, results='asis', echo=FALSE}
+```{r _shap, results='asis'}
 # Dynamically render shap code based on whether they are enabled for model run
 # https://www.harveyl888.com/post/2022-05-12-knit_child_quarto/
 if (shap_exists) {
@@ -45,7 +47,7 @@ if (shap_exists) {
 }
 ```
 
-```{r, results='asis', echo=FALSE}
+```{r _comp, results='asis'}
 if (comp_exists) {
   comp_qmd <- knitr::knit_child("_comp.qmd", quiet = TRUE)
   cat(comp_qmd, sep = "\n")

--- a/reports/performance/performance.qmd
+++ b/reports/performance/performance.qmd
@@ -24,7 +24,7 @@ params:
   year: "2025"
 ---
 
-```{r _setup}
+```{r _setup_script}
 source("../_setup.R")
 ```
 


### PR DESCRIPTION
This PR fixes some annoying rendering bugs within the Quarto performance report. Mainly:

- Code is being echoed (shown in the output report) due to the use of the [includes shortcode](https://quarto.org/docs/authoring/includes.html) within conditional chunks
- Maps are not rendering, seemingly due to the same issue

Both these bugs seem caused by a change to the way Quarto performs rendering. See my PR comments for details.