### PR TITLE
Fix comps link security/reference problem

### DIFF
--- a/pipeline/07-export.R
+++ b/pipeline/07-export.R
@@ -600,18 +600,12 @@ for (town in unique(assessment_pin_prepped$township_code)) {
       comp_pin_1 = ifelse(
         is.na(comp_pin_1_coord),
         NA,
-        glue::glue(
-          '=HYPERLINK(@CELL("address",{comp_sheet_name}!{comp_pin_1_coord}),',
-          '"{comp_pin_1}")'
-        )
+        glue::glue('=HYPERLINK("#{comp_sheet_name}!{comp_pin_1_coord}", "{comp_pin_1}")')
       ),
       comp_pin_2 = ifelse(
         is.na(comp_pin_2_coord),
         NA,
-        glue::glue(
-          '=HYPERLINK(@CELL("address",{comp_sheet_name}!{comp_pin_2_coord}),',
-          '"{comp_pin_2}")'
-        )
+        glue::glue('=HYPERLINK("#{comp_sheet_name}!{comp_pin_2_coord}", "{comp_pin_2}")')
       )
     ) %>%
     select(-ends_with("_coord"))

--- a/pipeline/07-export.R
+++ b/pipeline/07-export.R
@@ -600,12 +600,16 @@ for (town in unique(assessment_pin_prepped$township_code)) {
       comp_pin_1 = ifelse(
         is.na(comp_pin_1_coord),
         NA,
-        glue::glue('=HYPERLINK("#{comp_sheet_name}!{comp_pin_1_coord}", "{comp_pin_1}")')
+        glue::glue(
+          '=HYPERLINK("#{comp_sheet_name}!{comp_pin_1_coord}", "{comp_pin_1}")'
+        )
       ),
       comp_pin_2 = ifelse(
         is.na(comp_pin_2_coord),
         NA,
-        glue::glue('=HYPERLINK("#{comp_sheet_name}!{comp_pin_2_coord}", "{comp_pin_2}")')
+        glue::glue(
+          '=HYPERLINK("#{comp_sheet_name}!{comp_pin_2_coord}", "{comp_pin_2}")'
+        )
       )
     ) %>%
     select(-ends_with("_coord"))


### PR DESCRIPTION
Fixes the formula used to link out to the comps sheet from the pin detail sheet in the desk review workbook.

I've verified the output functions correctly.