### PR TITLE
Fix missing sales validation reasons in DR workbooks

### DIFF
--- a/pipeline/02-assess.R
+++ b/pipeline/02-assess.R
@@ -382,12 +382,13 @@ sales_data_ratio_study <- sales_data %>%
 sales_data_two_most_recent <- sales_data %>%
   distinct(
     meta_pin, meta_year,
-    meta_sale_price, meta_sale_date, meta_sale_document_num,
+    meta_sale_price, meta_sale_date, meta_sale_document_num, sv_is_outlier,
     sv_outlier_reason1, sv_outlier_reason2, sv_outlier_reason3
   ) %>%
   # Include outliers, since these data are used for desk review and
   # not for modeling
   rename(
+    meta_sale_is_outlier = sv_is_outlier,
     meta_sale_outlier_reason1 = sv_outlier_reason1,
     meta_sale_outlier_reason2 = sv_outlier_reason2,
     meta_sale_outlier_reason3 = sv_outlier_reason3
@@ -402,6 +403,7 @@ sales_data_two_most_recent <- sales_data %>%
       meta_sale_date,
       meta_sale_price,
       meta_sale_document_num,
+      meta_sale_is_outlier,
       meta_sale_outlier_reason1,
       meta_sale_outlier_reason2,
       meta_sale_outlier_reason3
@@ -534,7 +536,7 @@ assessment_pin_data_final <- assessment_pin_data_sale %>%
   mutate(
     flag_prior_near_to_pred_unchanged =
       prior_near_tot >= pred_pin_final_fmv_round - 100 &
-        prior_near_tot <= pred_pin_final_fmv_round + 100, # nolint
+      prior_near_tot <= pred_pin_final_fmv_round + 100, # nolint
     flag_pred_initial_to_final_changed = ccao::val_round_fmv(
       pred_pin_initial_fmv,
       breaks = params$pv$round_break,

--- a/pipeline/02-assess.R
+++ b/pipeline/02-assess.R
@@ -536,7 +536,7 @@ assessment_pin_data_final <- assessment_pin_data_sale %>%
   mutate(
     flag_prior_near_to_pred_unchanged =
       prior_near_tot >= pred_pin_final_fmv_round - 100 &
-      prior_near_tot <= pred_pin_final_fmv_round + 100, # nolint
+        prior_near_tot <= pred_pin_final_fmv_round + 100, # nolint
     flag_pred_initial_to_final_changed = ccao::val_round_fmv(
       pred_pin_initial_fmv,
       breaks = params$pv$round_break,

--- a/pipeline/07-export.R
+++ b/pipeline/07-export.R
@@ -434,7 +434,18 @@ assessment_pin_prepped <- assessment_pin_merged %>%
   # Add assessable permit flag
   left_join(flag_assessable_permits, by = c("meta_pin" = "pin")) %>%
   mutate(
-    flag_has_recent_assessable_permit = as.numeric(has_recent_assessable_permit)
+    flag_has_recent_assessable_permit =
+      as.numeric(has_recent_assessable_permit),
+    sale_recent_1_outlier_reasons = paste0(
+      sale_recent_1_outlier_reason1,
+      ", ",
+      sale_recent_1_outlier_reason2
+    ),
+    sale_recent_2_outlier_reasons = paste0(
+      sale_recent_2_outlier_reason1,
+      ", ",
+      sale_recent_2_outlier_reason2
+    )
   ) %>%
   # Select fields for output to workbook
   select(
@@ -449,9 +460,9 @@ assessment_pin_prepped <- assessment_pin_merged %>%
     prior_near_yoy_change_nom, prior_near_yoy_change_pct,
     sale_ratio, valuations_note,
     sale_recent_1_date, sale_recent_1_price,
-    sale_recent_1_outlier_type, sale_recent_1_document_num,
+    sale_recent_1_outlier_reasons, sale_recent_1_document_num,
     sale_recent_2_date, sale_recent_2_price,
-    sale_recent_2_outlier_type, sale_recent_2_document_num,
+    sale_recent_2_outlier_reasons, sale_recent_2_document_num,
     char_yrblt, char_beds, char_ext_wall, char_bsmt, char_bsmt_fin, char_air,
     char_heat, char_total_bldg_sf, char_type_resd, char_land_sf, char_apts,
     char_ncu,

--- a/pipeline/07-export.R
+++ b/pipeline/07-export.R
@@ -17,6 +17,7 @@ suppressPackageStartupMessages({
   library(openxlsx)
   library(noctua)
   library(readr)
+  library(stringr)
 })
 
 # Establish Athena connection
@@ -436,16 +437,24 @@ assessment_pin_prepped <- assessment_pin_merged %>%
   mutate(
     flag_has_recent_assessable_permit =
       as.numeric(has_recent_assessable_permit),
-    sale_recent_1_outlier_reasons = paste0(
-      sale_recent_1_outlier_reason1,
-      ", ",
-      sale_recent_1_outlier_reason2
-    ),
-    sale_recent_2_outlier_reasons = paste0(
-      sale_recent_2_outlier_reason1,
-      ", ",
-      sale_recent_2_outlier_reason2
-    )
+    sale_recent_1_outlier_reasons = str_remove_all(ifelse(
+      sale_recent_1_is_outlier,
+      paste(
+        str_replace_na(sale_recent_1_outlier_reason1, ""),
+        str_replace_na(sale_recent_1_outlier_reason2, ""),
+        sep = ", "
+      ),
+      NA_character_
+    ), ", $"),
+    sale_recent_2_outlier_reasons = str_remove_all(ifelse(
+      sale_recent_2_is_outlier,
+      paste(
+        str_replace_na(sale_recent_2_outlier_reason1, ""),
+        str_replace_na(sale_recent_2_outlier_reason2, ""),
+        sep = ", "
+      ),
+      NA_character_
+    ), ", $")
   ) %>%
   # Select fields for output to workbook
   select(


### PR DESCRIPTION
The Desk Review workbooks were still exporting a legacy sales validation field. This updates the export script to use the correct new fields.