### PR TITLE
Fix shaps and comps to work with multi-card solution

### DIFF
--- a/pipeline/02-assess.R
+++ b/pipeline/02-assess.R
@@ -105,7 +105,7 @@ assessment_card_data_mc <- assessment_card_data_pred %>%
   # that prediction as the PIN value. For > 3 cards, we predict each card with
   # its original square footage then sum the predictions to get the PIN value
   group_by(meta_pin) %>%
-  arrange(meta_pin, desc(char_bldg_sf)) %>%
+  arrange(meta_pin, desc(char_bldg_sf), meta_card_num) %>%  # Added meta_card_num as tiebreaker
   mutate(
     pred_pin_card_sum = ifelse(
       meta_pin_num_cards > 3,
@@ -536,7 +536,7 @@ assessment_pin_data_final <- assessment_pin_data_sale %>%
   mutate(
     flag_prior_near_to_pred_unchanged =
       prior_near_tot >= pred_pin_final_fmv_round - 100 &
-        prior_near_tot <= pred_pin_final_fmv_round + 100, # nolint
+      prior_near_tot <= pred_pin_final_fmv_round + 100, # nolint
     flag_pred_initial_to_final_changed = ccao::val_round_fmv(
       pred_pin_initial_fmv,
       breaks = params$pv$round_break,

--- a/pipeline/02-assess.R
+++ b/pipeline/02-assess.R
@@ -536,7 +536,7 @@ assessment_pin_data_final <- assessment_pin_data_sale %>%
   mutate(
     flag_prior_near_to_pred_unchanged =
       prior_near_tot >= pred_pin_final_fmv_round - 100 &
-      prior_near_tot <= pred_pin_final_fmv_round + 100, # nolint
+        prior_near_tot <= pred_pin_final_fmv_round + 100, # nolint
     flag_pred_initial_to_final_changed = ccao::val_round_fmv(
       pred_pin_initial_fmv,
       breaks = params$pv$round_break,

--- a/pipeline/02-assess.R
+++ b/pipeline/02-assess.R
@@ -105,7 +105,7 @@ assessment_card_data_mc <- assessment_card_data_pred %>%
   # that prediction as the PIN value. For > 3 cards, we predict each card with
   # its original square footage then sum the predictions to get the PIN value
   group_by(meta_pin) %>%
-  arrange(meta_pin, desc(char_bldg_sf), meta_card_num) %>%  # Added meta_card_num as tiebreaker
+  arrange(meta_pin, desc(char_bldg_sf), meta_card_num) %>%
   mutate(
     pred_pin_card_sum = ifelse(
       meta_pin_num_cards > 3,

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -31,7 +31,9 @@ if (shap_enable || comp_enable) {
   # PINs) that need values. Will use the the trained model to calc SHAP values
   assessment_data <- as_tibble(read_parquet(paths$input$assessment$local))
 
-  # Apply the same square footage aggregation logic for multi-card PINs
+  # Aggregate square footage to building level. We do this to ensure consistent
+  # shap values based on the generated prediction for multi-card pins. More
+  # details in multi-card handling in the assess stage.
   assessment_data <- assessment_data %>%
     mutate(
       char_bldg_sf = ifelse(

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -117,7 +117,6 @@ if (shap_enable) {
       shap_cols <- c("pred_card_shap_baseline_fmv", params$model$predictor$all)
       # If the first row indicates 2 or 3 cards,
       # duplicate its SHAP values across the group
-      # https://github.com/ccao-data/model-res-avm/issues/358#issue-2897826811
       if (.x$meta_pin_num_cards[1] %in% c(2, 3)) {
         .x[shap_cols] <- .x[rep(1, nrow(.x)), shap_cols]
       }

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -185,20 +185,20 @@ if (comp_enable) {
   # aggregating the bldg_sf to a single card, and using that card to predict
   # the value for the multi-card PIN as a whole Since we don't predict on the
   # other cards, we set them aside for comp generation, to re-attach them later
-  multicard_pins <- comp_assessment_data_preprocess %>%
+  small_multicards <- comp_assessment_data_preprocess %>%
     filter(meta_pin_num_cards %in% c(2, 3))
 
-  selected_cards <- multicard_pins %>%
+  frankencards <- small_multicards %>%
     group_by(meta_pin) %>%
     arrange(sqft_card_num_sort) %>%
     slice(1) %>%
     ungroup()
 
-  singlecard_pins <- comp_assessment_data_preprocess %>%
-    filter(!meta_pin %in% multicard_pins$meta_pin)
+  single_cards_and_large_multicards <- comp_assessment_data_preprocess %>%
+    filter(!meta_pin %in% small_multicards$meta_pin)
 
-  comp_assessment_data_intermediate <-
-    bind_rows(singlecard_pins, selected_cards)
+  comp_assessment_data <-
+    bind_rows(single_cards_and_large_multicards, frankencards)
 
   comp_assessment_data_prepped <- recipes::bake(
     object = lgbm_final_full_recipe,

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -316,8 +316,11 @@ if (comp_enable) {
   # that we used for the main frankencard used for prediction
   removed_cards <- multicard_props %>%
     filter(
-      !(paste(meta_pin, meta_card_num) %in%
-        paste(selected_cards$meta_pin, selected_cards$meta_card_num))
+      !(
+        paste(
+          meta_pin, meta_card_num
+        ) %in% paste(selected_cards$meta_pin, selected_cards$meta_card_num)
+      )
     ) %>%
     select(meta_pin, meta_card_num)
 

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -315,13 +315,7 @@ if (comp_enable) {
   # Grab removed multi_card_cards,re-add them, and assign them the comps data
   # that we used for the main frankencard used for prediction
   removed_cards <- multicard_props %>%
-    filter(
-      !(
-        paste(
-          meta_pin, meta_card_num
-        ) %in% paste(selected_cards$meta_pin, selected_cards$meta_card_num)
-      )
-    ) %>%
+    anti_join(selected_cards, by = c("meta_pin", "meta_card_num")) %>%
     select(meta_pin, meta_card_num)
 
   removed_cards_comps <- removed_cards %>%

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -34,7 +34,6 @@ if (shap_enable || comp_enable) {
   # Apply the same square footage aggregation logic for multi-card PINs
   assessment_data <- assessment_data %>%
     mutate(
-      og_char_bldg_sf = char_bldg_sf,  # Save the original square footage
       char_bldg_sf = ifelse(
         ind_pin_is_multicard & meta_pin_num_cards %in% c(2, 3),
         sum(char_bldg_sf),

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -94,14 +94,17 @@ if (shap_enable) {
     ) %>%
     bind_cols(shap_values_tbl) %>%
     select(
-      meta_year, meta_pin, meta_card_num, meta_pin_num_cards, pred_card_shap_baseline_fmv,
+      meta_year, meta_pin, meta_card_num,
+      meta_pin_num_cards, pred_card_shap_baseline_fmv,
       all_of(params$model$predictor$all), township_code
     ) %>%
     group_by(meta_pin) %>%
     arrange(desc(char_bldg_sf), meta_card_num) %>%
     group_modify(~ {
       shap_cols <- c("pred_card_shap_baseline_fmv", params$model$predictor$all)
-      # If the first row indicates 2 or 3 cards, duplicate its SHAP values across the group.
+      # If the first row indicates 2 or 3 cards,
+      # duplicate its SHAP values across the group
+      # https://github.com/ccao-data/model-res-avm/issues/358#issue-2897826811
       if (.x$meta_pin_num_cards[1] %in% c(2, 3)) {
         .x[shap_cols] <- .x[rep(1, nrow(.x)), shap_cols]
       }

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -173,8 +173,7 @@ if (comp_enable) {
         filter(triad_name == tools::toTitleCase(params$assessment$triad)) %>%
         pull(township_code)
     )
-  ) %>% # TODO: Remove this before merging
-    filter(meta_pin_num_cards %in% c(2, 3))
+  )
 
   # Multi-card handling. For multi-card pins with 2-3 cards, we predict by
   # aggregating the bldg_sf to a single card, and using that card to predict
@@ -324,7 +323,7 @@ if (comp_enable) {
 
   final_comps_data <- cbind(comps[[1]], comps[[2]])
 
-  # Grab removed multi_card_cards,re-add them, and assign them the comps data
+  # Grab removed multi-card cards,re-add them, and assign them the comps data
   # that we used for the main frankencard used for prediction
   removed_cards <- multicard_pins %>%
     anti_join(selected_cards, by = c("meta_pin", "meta_card_num")) %>%

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -214,7 +214,6 @@ if (comp_enable) {
   # leaf node assignments based on the most important features.
   # To do this, we need the training data so that we can compute the mean sale
   # price and use it as the base model error
-  # Details here: https://github.com/ccao-data/model-res-avm/issues/358
   message("Extracting weights from training data")
   training_data <- read_parquet(paths$input$training$local) %>%
     filter(!ind_pin_is_multicard, !sv_is_outlier) %>%

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -183,7 +183,7 @@ if (comp_enable) {
 
   # Multi-card handling. For multi-card pins with 2-3 cards, we predict by
   # aggregating the bldg_sf to a single card, and using that card to predict
-  # which becomes the value for the mult-card pin. Since we don't predict on the
+  # the value for the multi-card PIN as a whole Since we don't predict on the
   # other cards, we set them aside for comp generation, to re-attach them later
   multicard_pins <- comp_assessment_data_preprocess %>%
     filter(meta_pin_num_cards %in% c(2, 3))

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -37,7 +37,9 @@ if (shap_enable || comp_enable) {
   # predicting values for these parcels. More details in multi-card handling
   # step in the assess stage.
 
-  # Persist sort order
+  # Start by persisting card sort order for the purposes of aggregating building square
+  # footage. We use characteristics from the largest card ("frankencard") in order to
+  # predict value, so we save the card sort order as a way to reference this card later on
   assessment_data_ordered <- assessment_data %>%
     group_by(meta_pin) %>%
     arrange(desc(char_bldg_sf), meta_card_num) %>%

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -13,7 +13,22 @@ tictoc::tic("Interpret")
 purrr::walk(list.files("R/", "\\.R$", full.names = TRUE), source)
 
 
-
+# # Exclude undesired columns (add "meta_card_num" if that's the one to ignore)
+# feature_cols <- setdiff(names(assessment_data), c("meta_pin", "meta_pin_card_num", "meta_card_num", "meta_pin_num_cards", "char_bldg_sf"))
+#
+# result <- assessment_data %>%
+#   group_by(meta_pin) %>%
+#   filter(first(meta_pin_num_cards) %in% c(2, 3)) %>%      # meta_pin_num_cards condition
+#   filter(any(duplicated(char_bldg_sf))) %>%               # char_bldg_sf duplicate condition
+#   summarise(across(all_of(feature_cols), ~ n_distinct(.x))) %>% # count distinct feature values
+#   rowwise() %>%
+#   mutate(
+#     has_diff = any(c_across(all_of(feature_cols)) > 1),
+#     differing_features = paste(feature_cols[which(c_across(all_of(feature_cols)) > 1)], collapse = "_")
+#   ) %>%
+#   ungroup() %>%
+#   filter(has_diff) %>%
+#   select(meta_pin, differing_features)
 
 #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # 2. Load Data -----------------------------------------------------------------
@@ -27,9 +42,28 @@ lgbm_final_full_recipe <- readRDS(paths$output$workflow_recipe$local)
 if (shap_enable || comp_enable) {
   message("Loading assessment data for SHAP and comp calculation")
 
+  df_verify_frankencard <- read_parquet("df_to_grab_consistent_frankencard.parquet") %>%
+    as_tibble()
+
   # Load the input data used for assessment. This is the universe of CARDs (not
-  # PINs) that need values. Will use the the trained model to calc SHAP values
+  # PINs) that need values. Will use the trained model to calculate SHAP values
   assessment_data <- as_tibble(read_parquet(paths$input$assessment$local))
+
+  assessment_data <- as.data.table(assessment_data)
+
+  assessment_data <- as_tibble(assessment_data[meta_pin_num_cards %in% c(2, 3)])
+
+  # Apply the same square footage aggregation logic for multi-card PINs
+  assessment_data <- assessment_data %>%
+    mutate(
+      og_char_bldg_sf = char_bldg_sf,  # Save the original square footage
+      char_bldg_sf = ifelse(
+        ind_pin_is_multicard & meta_pin_num_cards %in% c(2, 3),
+        sum(char_bldg_sf),
+        char_bldg_sf
+      ),
+      .by = meta_pin
+    )
 
   # Run the saved recipe on the assessment data to format it for prediction
   assessment_data_prepped <- recipes::bake(
@@ -47,7 +81,7 @@ if (comp_enable) {
 }
 
 
-
+#TODO:  store those SHAPs and comps for all cards, even the smaller ones.
 
 #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # 3. Calculate SHAP Values -----------------------------------------------------
@@ -56,7 +90,7 @@ if (comp_enable) {
 if (shap_enable) {
   message("Calculating SHAP values")
 
-  # Calculate a SHAP value for each observation for each feature in the
+  # Calculate a SHAP value for each observation for each feature in the %>%
   # assessment data. Uses lightgbm's built-in method (predcontrib = TRUE)
   shap_values <- predict(
     object = lgbm_final_full_fit$fit,
@@ -77,19 +111,208 @@ if (shap_enable) {
   shap_values_final <- assessment_data %>%
     select(
       meta_year, meta_pin, meta_card_num,
+      meta_pin_num_cards,
       township_code = meta_township_code
     ) %>%
     bind_cols(shap_values_tbl) %>%
     select(
-      meta_year, meta_pin, meta_card_num, pred_card_shap_baseline_fmv,
+      meta_year, meta_pin, meta_card_num, meta_pin_num_cards,
+      pred_card_shap_baseline_fmv,
       all_of(params$model$predictor$all), township_code
     ) %>%
-    write_parquet(paths$output$shap$local)
+    group_by(meta_pin) %>%
+    arrange(meta_pin, desc(char_bldg_sf)) %>%
+    mutate(
+      first_selection = ifelse(row_number() == 1, 1, 0)
+    ) %>%
+    arrange(meta_pin, meta_card_num) %>%
+    ungroup() #%>%
+    #write_parquet(paths$output$shap$local)
 } else {
   # If SHAP creation is disabled, we still need to write an empty stub file
   # so DVC doesn't complain
   arrow::write_parquet(data.frame(), paths$output$shap$local)
 }
+
+#
+#
+#
+# Work space - check predictions. try to get pred for shap and match to original output
+#
+#
+#
+
+# Load additional dev R libraries (see README#managing-r-dependencies)
+suppressPackageStartupMessages({
+  library(DBI)
+  library(igraph)
+  library(noctua)
+})
+
+# Adds arrow support to speed up ingest process.
+noctua_options(unload = FALSE)
+
+# Establish Athena connection
+AWS_ATHENA_CONN_NOCTUA <- dbConnect(
+  noctua::athena(),
+  rstudio_conn_tab = FALSE
+)
+
+assesment_pin_mc_model_preds <- dbGetQuery(
+  conn = AWS_ATHENA_CONN_NOCTUA, glue("
+  SELECT * FROM model.assessment_pin
+  where run_id = '2025-02-11-charming-eric'
+  and meta_pin_num_cards IN (2, 3)
+  ")
+)
+
+
+# -----------------------------------------------------------------------------
+# Helper Function: Pivot predictions and compute ratio
+# -----------------------------------------------------------------------------
+compute_ratio <- function(df, ratio_col) {
+  df %>%
+    select(meta_pin, prediction, prediction_type) %>%
+    pivot_wider(names_from = prediction_type, values_from = prediction) %>%
+    mutate(!!ratio_col := shapped_pred / pred_pin_final_fmv)
+}
+
+# -----------------------------------------------------------------------------
+# 1. Transform Predictions into a Unified Format
+# -----------------------------------------------------------------------------
+shap_preds <- shap_values_final %>%
+  mutate(shapped_pred = rowSums(across(pred_card_shap_baseline_fmv:shp_parcel_num_vertices))) %>%
+  transmute(
+    meta_pin,
+    meta_card_num,
+    first_selection,
+    prediction      = shapped_pred,
+    prediction_type = "shapped_pred"
+  )
+
+athena_preds <- assesment_pin_mc_model_preds %>%
+  transmute(
+    meta_pin,
+    meta_tieback_key_pin,
+    meta_tieback_proration_rate,
+    prediction      = pred_pin_final_fmv,
+    prediction_type = "pred_pin_final_fmv",
+    meta_card_num   = NA
+  )
+
+combined_preds <- bind_rows(athena_preds, shap_preds) %>%
+  arrange(meta_pin)
+
+# -----------------------------------------------------------------------------
+# 2. Identify PINs with Duplicate Square Footage ("SqFt Ties")
+# -----------------------------------------------------------------------------
+sqft_ties <- read_parquet(paths$input$assessment$local) %>%
+  as_tibble() %>%
+  group_by(meta_pin) %>%
+  filter(
+    first(meta_pin_num_cards) %in% 2:3,
+    char_bldg_sf %in% char_bldg_sf[duplicated(char_bldg_sf)]
+  ) %>%
+  ungroup() %>%
+  distinct(meta_pin) %>%
+  pull(meta_pin)
+
+# -----------------------------------------------------------------------------
+# 3. Filter Combined Predictions for SqFt Tie Cases
+#    - final_inspection_all: all rows from combined_preds for these PINs
+#    - final_inspection_first: only rows where either:
+#         * prediction_type == "pred_pin_final_fmv" OR
+#         * prediction_type == "shapped_pred" AND first_selection == 1
+# -----------------------------------------------------------------------------
+final_inspection_all <- combined_preds %>%
+  filter(meta_pin %in% sqft_ties)
+
+# final_inspection_first <- final_inspection_all %>%
+#   filter(
+#     prediction_type == "pred_pin_final_fmv" |
+#       (prediction_type == "shapped_pred" & meta_card_num == 1)
+#   )
+final_inspection_first <- final_inspection_all %>%
+  group_by(meta_pin) %>%
+  mutate(min_meta_card_num = min(meta_card_num[prediction_type == "shapped_pred"], na.rm = TRUE)) %>%
+  filter(
+    prediction_type == "pred_pin_final_fmv" |
+      (prediction_type == "shapped_pred" & meta_card_num == min_meta_card_num)
+  ) %>%
+  ungroup() %>%
+  select(-min_meta_card_num)
+
+
+# Count occurrences of meta_pin
+final_inspection_first %>%
+  group_by(meta_pin) %>%
+  filter(n() == 1) %>%
+  ungroup()
+
+# -----------------------------------------------------------------------------
+# 4. Compute Ratio: (SHAP-Based Prediction) / (Model FMV)
+#    for first-selection rows
+# -----------------------------------------------------------------------------
+shap_fmv_ratio <- compute_ratio(final_inspection_first, "pred_ratio")
+
+# -----------------------------------------------------------------------------
+# 5. Merge with Complex/Proration Data
+# -----------------------------------------------------------------------------
+complex_data <- assessment_data %>%
+  left_join(
+    read_parquet(paths$input$complex_id$local) %>% select(meta_pin, meta_complex_id),
+    by = "meta_pin"
+  ) %>%
+  distinct(meta_pin, meta_complex_id, meta_tieback_key_pin, meta_tieback_proration_rate)
+
+final_ordered_inspection <- shap_fmv_ratio %>%
+  left_join(complex_data, by = "meta_pin")
+
+# -----------------------------------------------------------------------------
+# 6. Validate Index-Based Method for All PINs
+#    Use df_verify_frankencard to verify shap predictions against valid index pairs
+# -----------------------------------------------------------------------------
+not_shap <- final_inspection_all %>%
+  filter(prediction_type != "shapped_pred")
+
+shap_verified <- final_inspection_all %>%
+  filter(prediction_type == "shapped_pred") %>%
+  semi_join(df_verify_frankencard, by = c("meta_pin", "meta_card_num"))
+
+all_index_preds <- bind_rows(not_shap, shap_verified)
+
+franken_ratio <- compute_ratio(all_index_preds, "pred_ratio_franken_index") %>%
+  select(meta_pin, pred_ratio_franken_index)
+
+# -----------------------------------------------------------------------------
+# 7. Final Comparison: Join the Two Ratios & Complex Data
+# -----------------------------------------------------------------------------
+final_comparison <- final_ordered_inspection %>%
+  left_join(franken_ratio, by = "meta_pin") %>%
+  select(meta_pin:pred_ratio, pred_ratio_franken_index, meta_complex_id:meta_tieback_proration_rate)
+
+final_comparison %>%
+  select(meta_pin, pred_ratio, pred_ratio_franken_index, meta_complex_id, meta_tieback_key_pin) %>% View()
+
+
+
+# GET BINS -----------------------------------------------------
+# Define breaks for binning (0.05 intervals)
+breaks <- seq(floor(min(final_comparison$pred_ratio) * 20) / 20,
+              ceiling(max(final_comparison$pred_ratio) * 20) / 20,
+              by = 0.01)
+
+# Bin the pred_ratio column
+final_comparison_bins <- final_comparison %>%
+  filter(is.na(meta_complex_id), is.na(meta_tieback_key_pin)) %>%
+  mutate(bin = cut(pred_ratio, breaks = breaks, include.lowest = TRUE, right = FALSE))
+
+# Count occurrences in each bin
+bin_counts <- final_comparison_bins %>%
+  count(bin) %>%
+  arrange(bin)
+
+
 
 
 

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -202,7 +202,7 @@ if (comp_enable) {
 
   comp_assessment_data_prepped <- recipes::bake(
     object = lgbm_final_full_recipe,
-    new_data = comp_assessment_data_intermediate,
+    new_data = comp_assessment_data,
     all_predictors()
   )
 
@@ -322,8 +322,8 @@ if (comp_enable) {
     ) %>%
     select(-starts_with("comp_idx_")) %>%
     cbind(
-      pin = comp_assessment_data_intermediate$meta_pin,
-      card = comp_assessment_data_intermediate$meta_card_num
+      pin = comp_assessment_data$meta_pin,
+      card = comp_assessment_data$meta_card_num
     ) %>%
     relocate(pin, card)
 
@@ -331,8 +331,8 @@ if (comp_enable) {
 
   # Grab removed small multi-cards, re-add them, and assign them the comps data
   # that we calculated for the frankencard
-  removed_cards <- multicard_pins %>%
-    anti_join(selected_cards, by = c("meta_pin", "meta_card_num")) %>%
+  removed_cards <- small_multicards %>%
+    anti_join(frankencards, by = c("meta_pin", "meta_card_num")) %>%
     select(meta_pin, meta_card_num)
 
   removed_cards_comps <- removed_cards %>%

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -113,9 +113,12 @@ if (shap_enable) {
       meta_pin_num_cards, pred_card_shap_baseline_fmv,
       all_of(params$model$predictor$all), township_code
     ) %>%
+    # Adjust small (2-3 card) multi-cards to copy the SHAPs from the
+    # "frankencard" to all of the cards in the PIN. This aligns with the way
+    # that we handle small multi-cards in the assess stage.
+    # Start by grouping and sorting the same way we do in the assess stage
+    # so that we can figure out which card is the frankencard
     group_by(meta_pin) %>%
-    # Replicate sort used in the assess stage to ensure the same card's chars
-    # are used accross the assess stage and interpret stage
     arrange(sqft_card_num_sort) %>%
     group_modify(~ {
       shap_cols <- c("pred_card_shap_baseline_fmv", params$model$predictor$all)

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -125,7 +125,7 @@ if (shap_enable) {
     }) %>%
     arrange(meta_pin, meta_card_num) %>%
     ungroup() %>%
-    select(-meta_pin_num_cards) %>%
+    select(-meta_pin_num_cards, -sqft_card_num_sort) %>%
     write_parquet(paths$output$shap$local)
 } else {
   # If SHAP creation is disabled, we still need to write an empty stub file

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -31,9 +31,11 @@ if (shap_enable || comp_enable) {
   # PINs) that need values. Will use the the trained model to calc SHAP values
   assessment_data <- as_tibble(read_parquet(paths$input$assessment$local))
 
-  # Aggregate square footage to building level. We do this to ensure consistent
-  # shap values and comps based on the generated prediction for multi-card pins.
-  # More details in multi-card handling in the assess stage.
+  # Aggregate square footage to the parcel level for small (2-3 card) multi-cards.
+  # We do this to ensure consistent SHAP values for small multi-card parcels,
+  # since we use aggregated parcel square footage when predicting values for
+  # these parcels.
+  # More details in multi-card handling step in the assess stage.
   # https://github.com/ccao-data/model-res-avm/issues/358
 
   # Persist sort order

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -317,7 +317,7 @@ if (comp_enable) {
   removed_cards <- multicard_props %>%
     filter(
       !(paste(meta_pin, meta_card_num) %in%
-          paste(selected_cards$meta_pin, selected_cards$meta_card_num))
+        paste(selected_cards$meta_pin, selected_cards$meta_card_num))
     ) %>%
     select(meta_pin, meta_card_num)
 

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -32,8 +32,8 @@ if (shap_enable || comp_enable) {
   assessment_data <- as_tibble(read_parquet(paths$input$assessment$local))
 
   # Aggregate square footage to building level. We do this to ensure consistent
-  # shap values based on the generated prediction for multi-card pins. More
-  # details in multi-card handling in the assess stage.
+  # shap values and comps based on the generated prediction for multi-card pins.
+  # More details in multi-card handling in the assess stage.
   # https://github.com/ccao-data/model-res-avm/issues/358
   assessment_data <- assessment_data %>%
     mutate(

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -37,9 +37,10 @@ if (shap_enable || comp_enable) {
   # predicting values for these parcels. More details in multi-card handling
   # step in the assess stage.
 
-  # Start by persisting card sort order for the purposes of aggregating building square
-  # footage. We use characteristics from the largest card ("frankencard") in order to
-  # predict value, so we save the card sort order as a way to reference this card later on
+  # Start by persisting card sort order for the purposes of aggregating
+  # building square footage. We use characteristics from the largest card
+  # ("frankencard") in order to predict value, so we save the card sort order
+  # as a way to reference this card later on
   assessment_data_ordered <- assessment_data %>%
     group_by(meta_pin) %>%
     arrange(desc(char_bldg_sf), meta_card_num) %>%

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -31,12 +31,11 @@ if (shap_enable || comp_enable) {
   # PINs) that need values. Will use the the trained model to calc SHAP values
   assessment_data <- as_tibble(read_parquet(paths$input$assessment$local))
 
-  # Aggregate square footage to the parcel level for small (2-3 card) multi-cards.
-  # We do this to ensure consistent SHAP values for small multi-card parcels,
-  # since we use aggregated parcel square footage when predicting values for
-  # these parcels.
-  # More details in multi-card handling step in the assess stage.
-  # https://github.com/ccao-data/model-res-avm/issues/358
+  # Aggregate square footage to the parcel level for small (2-3 card)
+  # multi-cards. We do this to ensure consistent SHAP values for small
+  # multi-card parcels, since we use aggregated parcel square footage when
+  # predicting values for these parcels. More details in multi-card handling
+  # step in the assess stage.
 
   # Persist sort order
   assessment_data_ordered <- assessment_data %>%

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -317,7 +317,7 @@ if (comp_enable) {
   removed_cards <- multicard_props %>%
     filter(
       !(paste(meta_pin, meta_card_num) %in%
-        paste(selected_cards$meta_pin, selected_cards$meta_card_num))
+          paste(selected_cards$meta_pin, selected_cards$meta_card_num))
     ) %>%
     select(meta_pin, meta_card_num)
 

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -168,8 +168,8 @@ if (comp_enable) {
   # algorithm
   comp_assessment_data_preprocess <- assessment_data %>%
     filter(
-    meta_township_code %in% (
-      ccao::town_dict %>%
+      meta_township_code %in% (
+        ccao::town_dict %>%
         filter(triad_name == tools::toTitleCase(params$assessment$triad)) %>%
         pull(township_code)
     )

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -183,7 +183,7 @@ if (comp_enable) {
 
   # Multi-card handling. For multi-card pins with 2-3 cards, we predict by
   # aggregating the bldg_sf to a single card, and using that card to predict
-  # the value for the multi-card PIN as a whole Since we don't predict on the
+  # the value for the multi-card PIN as a whole. Since we don't predict on the
   # other cards, we set them aside for comp generation, to re-attach them later
   small_multicards <- comp_assessment_data_preprocess %>%
     filter(meta_pin_num_cards %in% c(2, 3))

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -178,7 +178,7 @@ if (comp_enable) {
   # Multi-card handling. For multi-card pins with 2-3 cards, we predict by
   # aggregating the bldg_sf to a single card, and using that card to predict
   # which becomes the value for the mult-card pin. Since we don't predict on the
-  # other cards, we set them aside for comp generation re-attach them later
+  # other cards, we set them aside for comp generation, to re-attach them later
   multicard_pins <- comp_assessment_data_preprocess %>%
     filter(meta_pin_num_cards %in% c(2, 3))
 

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -327,24 +327,22 @@ if (comp_enable) {
     ) %>%
     relocate(pin, card)
 
-  final_comps_data <- cbind(comps[[1]], comps[[2]])
+  comp_idxs_and_scores <- cbind(comps[[1]], comps[[2]])
 
-  # Grab removed multi-card cards,re-add them, and assign them the comps data
-  # that we used for the main frankencard used for prediction
+  # Grab removed small multi-cards, re-add them, and assign them the comps data
+  # that we calculated for the frankencard
   removed_cards <- multicard_pins %>%
     anti_join(selected_cards, by = c("meta_pin", "meta_card_num")) %>%
     select(meta_pin, meta_card_num)
 
   removed_cards_comps <- removed_cards %>%
     rename(pin = meta_pin, card = meta_card_num) %>%
-    left_join(final_comps_data %>% select(-card), by = "pin")
-
-  complete_comps_data <-
-    bind_rows(final_comps_data, removed_cards_comps) %>%
-    arrange(pin, card)
+    left_join(comp_idxs_and_scores %>% select(-card), by = "pin")
 
   # Save final combined comps data
-  arrow::write_parquet(complete_comps_data, paths$output$comp$local)
+  bind_rows(comp_idxs_and_scores, removed_cards_comps) %>%
+    arrange(pin, card) %>%
+    arrow::write_parquet(paths$output$comp$local)
 } else {
   # If comp creation is disabled, we still need to write an empty stub file
   # so DVC doesn't complain

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -170,10 +170,10 @@ if (comp_enable) {
     filter(
       meta_township_code %in% (
         ccao::town_dict %>%
-        filter(triad_name == tools::toTitleCase(params$assessment$triad)) %>%
-        pull(township_code)
+          filter(triad_name == tools::toTitleCase(params$assessment$triad)) %>%
+          pull(township_code)
+      )
     )
-  )
 
   # Multi-card handling. For multi-card pins with 2-3 cards, we predict by
   # aggregating the bldg_sf to a single card, and using that card to predict

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -161,14 +161,14 @@ if (comp_enable) {
         pull(township_code)
     )
   ) %>% # TODO: Remove this before merging
-    filter(meta_pin_num_cards %in% c(2,3))
+    filter(meta_pin_num_cards %in% c(2, 3))
 
   # Multi-card handling. For multi-card pins with 2-3 cards, we predict by
   # aggregating the bldg_sf to a single card, and using that card to predict
   # which becomes the value for the mult-card pin. Since we don't predict on the
   # other cards, we set them aside for comp generation re-attach them later
   multicard_props <- comp_assessment_data_preprocess %>%
-    filter(meta_pin_num_cards %in% c(2,3))
+    filter(meta_pin_num_cards %in% c(2, 3))
 
   selected_cards <- multicard_props %>%
     group_by(meta_pin) %>%
@@ -214,6 +214,7 @@ if (comp_enable) {
   # leaf node assignments based on the most important features.
   # To do this, we need the training data so that we can compute the mean sale
   # price and use it as the base model error
+  # Details here: https://github.com/ccao-data/model-res-avm/issues/358
   message("Extracting weights from training data")
   training_data <- read_parquet(paths$input$training$local) %>%
     filter(!ind_pin_is_multicard, !sv_is_outlier) %>%
@@ -316,8 +317,8 @@ if (comp_enable) {
   removed_cards <- multicard_props %>%
     filter(
       !(paste(meta_pin, meta_card_num) %in%
-          paste(selected_cards$meta_pin, selected_cards$meta_card_num))
-      ) %>%
+        paste(selected_cards$meta_pin, selected_cards$meta_card_num))
+    ) %>%
     select(meta_pin, meta_card_num)
 
   removed_cards_comps <- removed_cards %>%

--- a/pipeline/04-interpret.R
+++ b/pipeline/04-interpret.R
@@ -195,7 +195,7 @@ if (comp_enable) {
     ungroup()
 
   single_cards_and_large_multicards <- comp_assessment_data_preprocess %>%
-    filter(!meta_pin %in% small_multicards$meta_pin)
+    filter(!meta_pin %in% frankencards$meta_pin)
 
   comp_assessment_data <-
     bind_rows(single_cards_and_large_multicards, frankencards)


### PR DESCRIPTION
This PR addresses #358. We edit the interpret stage such that shaps and comps are generated to be in line with our recent [multi-card methodology update](https://github.com/ccao-data/model-res-avm/commit/6ee2f119adbd1df016c8df71a6e25f926623b9d5). Within multi-card PINs, we essentially compute shaps and comps with a single-card, the card that was used for prediction in the `assess` stage. Then, we use that card's shaps and comps for each card within the multi-card PIN.

We also introduce another sorting mechanism which fixes an issue of tiebreaks within multi-card PINs. We were choosing the card to predict based on highest sqft. Sometimes the sqft was tied between two pins, which led to a tiebreak that we didn't have a rule for. Now, we give preference to the lowest `meta_card_num` within the PIN.