### PR TITLE
Fix weights matrix indexing bug

### DIFF
--- a/python/comps.py
+++ b/python/comps.py
@@ -111,7 +111,7 @@ def _get_top_n_comps(
                     leaf_node_matrix[x_i][tree_idx]
                     == comparison_leaf_node_matrix[y_i][tree_idx]
                 ):
-                    similarity_score += weights_matrix[x_i][tree_idx]
+                    similarity_score += weights_matrix[y_i][tree_idx]
 
             # See if the score is higher than any of the top N
             # comps, and store it in the sorted comps array if it is.


### PR DESCRIPTION
This PR fixes a small but impactful bug that affects the comps algorithm.

Terms:
- `observational_df` is the assessment data we are using for which we generate comps
- `comparison_df` is the leaf/tree information for the training data that we use to generate weights and compare similar leaf nodes with `observational_df`
- `weights_df` is the weights data that we use to produce similarity scores between assessment data leaf nodes and training data leaf nodes

We were computing the similarity score by indexing the `weights_matrix` by the row level index `x_i`  of the `observational_df`, and then selecting the tree leaf value with `tree_idx`. This results in similarity scores computed with incorrect weights.

```
similarity_score += weights_matrix[x_i][tree_idx]
```

Since the weights are generated from `comparison_df` rather than `observational_df`, we must use `[y_i]` (the iterator for `comparison_df`) instead of `[x_i]` (the iterator for `observational_df`).


```
similarity_score += weights_matrix[y_i][tree_idx]
```

