### PR TITLE
Add unit tests for `python.comps` module

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
           uv pip install -r requirements.txt
           uv pip install pytest~=8.3.5
 
-      - name: Run tests
+      - name: Run Python tests
         shell: bash
         working-directory: python
         run: pytest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,4 +37,4 @@ jobs:
       - name: Run tests
         shell: bash
         working-directory: python
-        run: pytest -v --cache-clear -rf
+        run: pytest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,40 @@
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+name: test
+
+env:
+  PYTHONUNBUFFERED: "1"
+  UV_SYSTEM_PYTHON: 1
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: requirements.txt
+          cache-suffix: pytest
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          uv pip install -r requirements.txt
+          uv pip install pytest~=8.3.5
+
+      - name: Run tests
+        shell: bash
+        working-directory: python
+        run: pytest -v --cache-clear -rf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,15 @@ repos:
         language: r
         additional_dependencies:
           - yaml
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.2
+    hooks:
+      # Python linter. Ruff recommends running this before the formatter to
+      # avoid conflicts when using the --fix flag
+      - id: ruff
+        args:
+          - --fix
+        files: ^python/
+      # Formatter
+      - id: ruff-format
+        files: ^python/

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,3 @@
+# Ignore uv lockfile because we use requirements.txt for this project, in order
+# to make it compatible with reticulate
+uv.lock

--- a/python/comps.py
+++ b/python/comps.py
@@ -10,7 +10,7 @@ def get_comps(
     comparison_df: pd.DataFrame,
     weights: np.ndarray,
     num_comps: int = 5,
-    num_chunks: int = 10
+    num_chunks: int = 10,
 ) -> typing.Tuple[pd.DataFrame, pd.DataFrame]:
     """
     Fast algorithm to get the top `num_comps` comps from a dataframe of
@@ -119,7 +119,7 @@ def _get_top_n_comps(
     leaf_node_matrix: np.ndarray,
     comparison_leaf_node_matrix: np.ndarray,
     weights_matrix: np.ndarray,
-    num_comps: int
+    num_comps: int,
 ) -> typing.Tuple[np.ndarray, np.ndarray]:
     """Helper function that takes matrices of leaf node assignments for
     observations in a tree model, a matrix of weights for each obs/tree, and an
@@ -169,9 +169,7 @@ def _get_top_n_comps(
 
 @nb.njit(fastmath=True)
 def _insert_at_idx_and_shift(
-    arr: np.ndarray,
-    elem: typing.Union[int, float],
-    idx: int
+    arr: np.ndarray, elem: typing.Union[int, float], idx: int
 ) -> np.ndarray:
     """Helper function to insert an element `elem` into a sorted numpy array `arr`
     at a given index `idx` and shift the subsequent elements down one index."""

--- a/python/comps.py
+++ b/python/comps.py
@@ -1,21 +1,56 @@
+import typing
+
 import numba as nb
 import numpy as np
 import pandas as pd
 
 
 def get_comps(
-    observation_df,
-    comparison_df,
-    weights,
-    num_comps=5,
-):
-    """Fast algorithm to get the top `num_comps` comps from a dataframe of lightgbm
-    leaf node assignments (`observation_df`) compared to a second dataframe of
-    assignments (`comparison_df`). Leaf nodes are weighted according to a tree
-    importance matrix `weights` and used to generate a similarity score and
-    return two dataframes, one a set of indices and the other a set of scores
-    for the `n` most similar comparables. More details on the underlying
-    algorithm here: https://ccao-data.github.io/lightsnip/articles/finding-comps.html
+    observation_df: pd.DataFrame,
+    comparison_df: pd.DataFrame,
+    weights: np.ndarray,
+    num_comps: int = 5,
+    num_chunks: int = 10
+) -> typing.Tuple[pd.DataFrame, pd.DataFrame]:
+    """
+    Fast algorithm to get the top `num_comps` comps from a dataframe of
+    lightgbm leaf node assignments (`observation_df`) compared to a second
+    dataframe of leaf node assignments (`comparison_df`).
+
+    Leaf nodes are weighted according to a tree importance matrix `weights`
+    and used to generate a similarity score. The function returns two
+    dataframes: One containing the indices of the most similar compararables
+    and the other containing their corresponding similarity scores.
+
+    More details on the underlying algorithm can be found here:
+    https://ccao-data.github.io/lightsnip/articles/finding-comps.html
+
+    Args:
+        observation_df (pandas.DataFrame):
+            DataFrame containing leaf node assignments for observations.
+        comparison_df (pandas.DataFrame):
+            DataFrame containing leaf node assignments for potential
+            comparables.
+        weights (numpy.ndarray):
+            Importance weights for leaf nodes, used to compute similarity
+            scores.
+        num_comps (int, optional):
+            Number of top comparables to return for each observation.
+            Default is 5.
+        num_chunks (int, optional):
+            Number of chunks to split observations for progress reporting.
+            Default is 10.
+
+    Returns:
+        tuple:
+            - pd.DataFrame:
+                DataFrame containing the indices of the `num_comps`
+                most similar comparables in `comparison_df`. The order of
+                rows will match the order of rows in `observation_df`.
+            - pd.DataFrame:
+                DataFrame containing similarity scores for the `num_comps`
+                most similar comparables. The order of rows will match the
+                order of rows in `observation_df`.
     """
     # Convert the weights to a numpy array so that we can take advantage of
     # numba acceleration later on
@@ -81,8 +116,11 @@ def get_comps(
 
 @nb.njit(fastmath=True, parallel=True)
 def _get_top_n_comps(
-    leaf_node_matrix, comparison_leaf_node_matrix, weights_matrix, num_comps
-):
+    leaf_node_matrix: np.ndarray,
+    comparison_leaf_node_matrix: np.ndarray,
+    weights_matrix: np.ndarray,
+    num_comps: int
+) -> typing.Tuple[np.ndarray, np.ndarray]:
     """Helper function that takes matrices of leaf node assignments for
     observations in a tree model, a matrix of weights for each obs/tree, and an
     integer `num_comps`, and returns a matrix where each observation is scored
@@ -130,7 +168,11 @@ def _get_top_n_comps(
 
 
 @nb.njit(fastmath=True)
-def _insert_at_idx_and_shift(arr, elem, idx):
+def _insert_at_idx_and_shift(
+    arr: np.ndarray,
+    elem: typing.Union[int, float],
+    idx: int
+) -> np.ndarray:
     """Helper function to insert an element `elem` into a sorted numpy array `arr`
     at a given index `idx` and shift the subsequent elements down one index."""
     arr[idx + 1 :] = arr[idx:-1]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "model-res-avm-python"
+version = "0.0.1"
+description = "Python code for the CCAO residential model AVM"
+requires-python = ">=3.10"
+
+[tool.pytest.ini_options]
+minversion = "7.0.0"
+addopts = "-v --cache-clear -rf"
+# Make sure the python/ subdir is correctly loaded into the PATH during
+# test execution
+pythonpath = ["."]

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,1 @@
+../requirements.txt

--- a/python/tests/test_comps.py
+++ b/python/tests/test_comps.py
@@ -6,7 +6,7 @@ import comps as comps_module
 
 
 @pt.mark.parametrize(
-    "leaf_nodes,training_leaf_nodes,tree_weights,num_comps,expected_comps,expected_scores",
+    "leaf_nodes,training_leaf_nodes,tree_weights,num_comps,num_chunks,expected_comps,expected_scores",
     [
         # Simple example that tests one input observation with uniform weights
         # to make sure that the algorithm correctly prioritizes comparison
@@ -16,6 +16,7 @@ import comps as comps_module
             pd.DataFrame([[1, 1, 0], [1, 0, 0], [0, 0, 0]]),
             np.array([0.333] * 9).reshape(3, 3),
             3,
+            1,
             pd.DataFrame(
                 {
                     "comp_idx_1": [0],
@@ -39,7 +40,7 @@ import comps as comps_module
                 },
                 dtype=np.float32,
             ),
-            id="simple_one_observation",
+            id="one_observation",
         ),
         # Extend the simple test to work with two observations to ensure
         # that the algorithm correctly prioritizes larger counts of matches
@@ -49,6 +50,7 @@ import comps as comps_module
             pd.DataFrame([[1, 1, 1], [1, 1, 2], [1, 2, 2], [2, 2, 2]]),
             np.array([0.333] * 12).reshape(4, 3),
             4,
+            1,
             pd.DataFrame(
                 {
                     # The first element of each column is the comp for the
@@ -77,7 +79,7 @@ import comps as comps_module
                 },
                 dtype=np.float32,
             ),
-            id="simple_two_observations",
+            id="two_observations",
         ),
         # Test to make sure that the tree weight vector is correctly applied
         # to break ties in situations where comparison observations have the
@@ -88,6 +90,7 @@ import comps as comps_module
             pd.DataFrame([[1, 1, 0], [1, 1, 0], [1, 1, 0]]),
             np.array([[0.5, 0.3, 0.2], [0.3, 0.2, 0.5], [0.2, 0.1, 0.7]]),
             3,
+            1,
             pd.DataFrame(
                 {"comp_idx_1": [0], "comp_idx_2": [1], "comp_idx_3": [2]},
                 dtype=np.int32,
@@ -102,7 +105,104 @@ import comps as comps_module
             ),
             id="weights_tiebreak",
         ),
-        # TODO: Test to make sure that chunking produces the correct values
+        # Test that score tiebreaks always prioritize the first comparison
+        # observation in the input array
+        pt.param(
+            pd.DataFrame([[1, 1, 1]]),
+            pd.DataFrame([[1, 1, 1], [1, 1, 1], [1, 1, 1]]),
+            np.array([0.333] * 9).reshape(3, 3),
+            3,
+            1,
+            pd.DataFrame(
+                {"comp_idx_1": [0], "comp_idx_2": [1], "comp_idx_3": [2]},
+                dtype=np.int32,
+            ),
+            pd.DataFrame(
+                {
+                    "comp_score_1": [0.333 * 3],
+                    "comp_score_2": [0.333 * 3],
+                    "comp_score_3": [0.333 * 3],
+                },
+                dtype=np.float32,
+            ),
+            id="score_tiebreak",
+        ),
+        # Test to make sure that chunking produces the correct values when
+        # there are _more_ chunks than observations
+        pt.param(
+            pd.DataFrame([[1, 1, 1], [2, 2, 2], [3, 3, 3]]),
+            pd.DataFrame([[1, 1, 1], [2, 2, 2], [3, 3, 3]]),
+            np.array([0.333] * 9).reshape(3, 3),
+            3,
+            10,
+            pd.DataFrame(
+                {
+                    "comp_idx_1": [0, 1, 2],
+                    "comp_idx_2": [-1, -1, -1],
+                    "comp_idx_3": [-1, -1, -1],
+                },
+                dtype=np.int32,
+            ),
+            pd.DataFrame(
+                {
+                    "comp_score_1": [0.333 * 3] * 3,
+                    "comp_score_2": [0.333 * 0] * 3,
+                    "comp_score_3": [0.333 * 0] * 3,
+                },
+                dtype=np.float32,
+            ),
+            id="more_chunks_than_observations",
+        ),
+        # Test to make sure that chunking produces the correct values when
+        # there are _fewer_ chunks than observations
+        pt.param(
+            pd.DataFrame([[1, 1, 1], [2, 2, 2], [3, 3, 3]]),
+            pd.DataFrame([[1, 1, 1], [2, 2, 2], [3, 3, 3]]),
+            np.array([0.333] * 9).reshape(3, 3),
+            3,
+            2,
+            pd.DataFrame(
+                {
+                    "comp_idx_1": [0, 1, 2],
+                    "comp_idx_2": [-1, -1, -1],
+                    "comp_idx_3": [-1, -1, -1],
+                },
+                dtype=np.int32,
+            ),
+            pd.DataFrame(
+                {
+                    "comp_score_1": [0.333 * 3] * 3,
+                    "comp_score_2": [0.333 * 0] * 3,
+                    "comp_score_3": [0.333 * 0] * 3,
+                },
+                dtype=np.float32,
+            ),
+            id="fewer_chunks_than_observations",
+        ),
+        # Test that comps will not make it into the output if we have more
+        # comparison observations with positive scores than `num_comps`
+        pt.param(
+            pd.DataFrame([[1, 1, 1]]),
+            pd.DataFrame([[1, 1, 1], [1, 1, 1], [1, 1, 1]]),
+            np.array([0.333] * 9).reshape(3, 3),
+            2,
+            1,
+            pd.DataFrame(
+                {
+                    "comp_idx_1": [0],
+                    "comp_idx_2": [1],
+                },
+                dtype=np.int32,
+            ),
+            pd.DataFrame(
+                {
+                    "comp_score_1": [0.333 * 3],
+                    "comp_score_2": [0.333 * 3],
+                },
+                dtype=np.float32,
+            ),
+            id="more_possible_comps_than_num_comps",
+        ),
     ],
 )
 def test_get_comps(
@@ -110,15 +210,65 @@ def test_get_comps(
     training_leaf_nodes,
     tree_weights,
     num_comps,
+    num_chunks,
     expected_comps,
     expected_scores,
 ):
-    """Test all of our common parametrized test cases"""
     comps, scores = comps_module.get_comps(
         leaf_nodes,
         training_leaf_nodes,
         tree_weights,
         num_comps,
+        num_chunks,
     )
     assert comps.equals(expected_comps)
     assert scores.equals(expected_scores)
+
+
+@pt.mark.parametrize(
+    "leaf_nodes,training_leaf_nodes,tree_weights,expected_exception,expected_msg",
+    [
+        pt.param(
+            pd.DataFrame([[1, 1]]),
+            pd.DataFrame([[1, 1, 1], [2, 2, 2], [3, 3, 3]]),
+            np.array([0.333] * 9).reshape(3, 3),
+            ValueError,
+            "Number of columns in `observation_df` (2) must match `comparison_df` (3)",
+            id="observation_comparison_shapes_match",
+        ),
+        pt.param(
+            pd.DataFrame([[1, 1, 1]]),
+            pd.DataFrame([[1, 1, 1], [2, 2, 2], [3, 3, 3]]),
+            np.array([0.333] * 4).reshape(2, 2),
+            ValueError,
+            "`comparison_df.shape` (3, 3) must match `weights.shape` (2, 2)",
+            id="comparison_weights_shapes_match",
+        ),
+    ],
+)
+def test_get_comps_raises_on_invalid_inputs(
+    leaf_nodes,
+    training_leaf_nodes,
+    tree_weights,
+    expected_exception,
+    expected_msg,
+):
+    with pt.raises(expected_exception) as exc_info:
+        comps_module.get_comps(leaf_nodes, training_leaf_nodes, tree_weights)
+    assert str(exc_info.value) == expected_msg
+
+
+@pt.mark.parametrize(
+    "arr, elem, idx, expected",
+    [
+        pt.param([1, 2, 4, 5, 0], 3, 2, [1, 2, 3, 4, 5], id="insert_middle"),
+        pt.param([2, 3, 4, 5, 0], 1, 0, [1, 2, 3, 4, 5], id="insert_start"),
+        pt.param([1, 2, 3, 4, 0], 5, 4, [1, 2, 3, 4, 5], id="insert_end"),
+        pt.param([0], 1, 0, [1], id="insert_single_element"),
+        pt.param([], 1, 0, [], id="insert_empty_array"),
+        pt.param([1, 2, 3, 4, 5], 6, 10, [1, 2, 3, 4, 5], id="insert_out_of_bounds"),
+    ],
+)
+def test_insert_at_idx_and_shift(arr, elem, idx, expected):
+    result = comps_module.insert_at_idx_and_shift(np.array(arr), elem, idx)
+    np.testing.assert_array_equal(result, np.array(expected))

--- a/python/tests/test_comps.py
+++ b/python/tests/test_comps.py
@@ -2,34 +2,92 @@ import numpy as np
 import pandas as pd
 import pytest as pt
 
-from ..comps import get_comps
+import comps as comps_module
 
 
 @pt.mark.parametrize(
-    "leaf_nodes,training_leaf_nodes,tree_weights,expected_comps,expected_scores",
+    "leaf_nodes,training_leaf_nodes,tree_weights,num_comps,expected_comps,expected_scores",
     [
+        # Simple example that tests one input observation with uniform weights
+        # to make sure that the algorithm correctly prioritizes comparison
+        # observations with the highest number of leaf node matches
         pt.param(
             pd.DataFrame([[1, 1, 1]]),
             pd.DataFrame([[1, 1, 0], [1, 0, 0], [0, 0, 0]]),
             np.array([0.333] * 9).reshape(3, 3),
+            3,
             pd.DataFrame(
-                {"comp_idx_1": [0], "comp_idx_2": [1], "comp_idx_3": [-1]},
+                {
+                    "comp_idx_1": [0],
+                    "comp_idx_2": [1],
+                    # Only two comparison observations have any leaf nodes that
+                    # match the input observation, so make sure that the third
+                    # comp is empty
+                    "comp_idx_3": [-1]
+                },
                 dtype=np.int32,
             ),
             pd.DataFrame(
                 {
+                    # The weights are identical for all trees, so the score
+                    # should just be the global weight multiplied by the
+                    # number of leaf nodes in the comparison observation
+                    # that match the input observation
                     "comp_score_1": [0.333 * 2],
                     "comp_score_2": [0.333 * 1],
                     "comp_score_3": [0.333 * 0]
                 },
                 dtype=np.float32,
             ),
-            id="simple_example"
+            id="simple_one_observation"
         ),
+        # Extend the simple test to work with two observations to ensure
+        # that the algorithm correctly prioritizes larger counts of matches
+        # even when there are multiple input observations
+        pt.param(
+            pd.DataFrame([[1, 1, 1], [2, 2, 2]]),
+            pd.DataFrame([[1, 1, 1], [1, 1, 2], [1, 2, 2], [2, 2, 2]]),
+            np.array([0.333] * 12).reshape(4, 3),
+            4,
+            pd.DataFrame(
+                {
+                    # The first element of each column is the comp for the
+                    # first input observation, and the second element is the
+                    # comp for the second input observation
+                    "comp_idx_1": [0, 3],
+                    "comp_idx_2": [1, 2],
+                    "comp_idx_3": [2, 1],
+                    "comp_idx_4": [-1, -1],
+                },
+                dtype=np.int32,
+            ),
+            pd.DataFrame(
+                {
+                    # The number of leaf nodes that match each comp are
+                    # identical between the two input observations, and all
+                    # trees have the same weights, so all we need to do to
+                    # compute the expected score is to multiply the global
+                    # weight by the number of leaf node matches and then copy
+                    # that to the second element in the score column to account
+                    # for both input observations
+                    "comp_score_1": [0.333 * 3] * 2,
+                    "comp_score_2": [0.333 * 2] * 2,
+                    "comp_score_3": [0.333 * 1] * 2,
+                    "comp_score_4": [0.333 * 0] * 2
+                },
+                dtype=np.float32,
+            ),
+            id="simple_two_observations"
+        ),
+        # Test to make sure that the tree weight vector is correctly applied
+        # to break ties in situations where comparison observations have the
+        # same number of matching leaf nodes but different weights for those
+        # leaf nodes
         pt.param(
             pd.DataFrame([[1, 1, 1]]),
             pd.DataFrame([[1, 1, 0], [1, 1, 0], [1, 1, 0]]),
             np.array([[0.5, 0.3, 0.2], [0.3, 0.2, 0.5], [0.2, 0.1, 0.7]]),
+            3,
             pd.DataFrame(
                 {"comp_idx_1": [0], "comp_idx_2": [1], "comp_idx_3": [2]},
                 dtype=np.int32,
@@ -43,21 +101,24 @@ from ..comps import get_comps
                 dtype=np.float32,
             ),
             id="weights_tiebreak"
-        )
-    ],
+        ),
+        # TODO: Test to make sure that chunking produces the correct values
+    ]
 )
 def test_get_comps(
     leaf_nodes,
     training_leaf_nodes,
     tree_weights,
+    num_comps,
     expected_comps,
-    expected_scores
+    expected_scores,
 ):
-    comps, scores = get_comps(
+    """Test all of our common parametrized test cases"""
+    comps, scores = comps_module.get_comps(
         leaf_nodes,
         training_leaf_nodes,
         tree_weights,
-        num_comps=3
+        num_comps,
     )
     assert comps.equals(expected_comps)
     assert scores.equals(expected_scores)

--- a/python/tests/test_comps.py
+++ b/python/tests/test_comps.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pandas as pd
+import pytest as pt
+
+from ..comps import get_comps
+
+
+@pt.mark.parametrize(
+    "leaf_nodes,training_leaf_nodes,tree_weights,expected_comps,expected_scores",
+    [
+        pt.param(
+            pd.DataFrame([[1, 1, 1]]),
+            pd.DataFrame([[1, 1, 0], [1, 0, 0], [0, 0, 0]]),
+            np.array([0.333] * 9).reshape(3, 3),
+            pd.DataFrame(
+                {"comp_idx_1": [0], "comp_idx_2": [1], "comp_idx_3": [-1]},
+                dtype=np.int32,
+            ),
+            pd.DataFrame(
+                {
+                    "comp_score_1": [0.333 * 2],
+                    "comp_score_2": [0.333 * 1],
+                    "comp_score_3": [0.333 * 0]
+                },
+                dtype=np.float32,
+            ),
+            id="simple_example"
+        ),
+        pt.param(
+            pd.DataFrame([[1, 1, 1]]),
+            pd.DataFrame([[1, 1, 0], [1, 1, 0], [1, 1, 0]]),
+            np.array([[0.5, 0.3, 0.2], [0.3, 0.2, 0.5], [0.2, 0.1, 0.7]]),
+            pd.DataFrame(
+                {"comp_idx_1": [0], "comp_idx_2": [1], "comp_idx_3": [2]},
+                dtype=np.int32,
+            ),
+            pd.DataFrame(
+                {
+                    "comp_score_1": [0.5 + 0.3],
+                    "comp_score_2": [0.3 + 0.2],
+                    "comp_score_3": [0.2 + 0.1]
+                },
+                dtype=np.float32,
+            ),
+            id="weights_tiebreak"
+        )
+    ],
+)
+def test_get_comps(
+    leaf_nodes,
+    training_leaf_nodes,
+    tree_weights,
+    expected_comps,
+    expected_scores
+):
+    comps, scores = get_comps(
+        leaf_nodes,
+        training_leaf_nodes,
+        tree_weights,
+        num_comps=3
+    )
+    assert comps.equals(expected_comps)
+    assert scores.equals(expected_scores)

--- a/python/tests/test_comps.py
+++ b/python/tests/test_comps.py
@@ -105,8 +105,8 @@ import comps as comps_module
             ),
             id="weights_tiebreak",
         ),
-        # Test that score tiebreaks always prioritize the first comparison
-        # observation in the input array
+        # Test that score tiebreaks always prioritize the first observation
+        # in the comparison array
         pt.param(
             pd.DataFrame([[1, 1, 1]]),
             pd.DataFrame([[1, 1, 1], [1, 1, 1], [1, 1, 1]]),

--- a/python/tests/test_comps.py
+++ b/python/tests/test_comps.py
@@ -23,7 +23,7 @@ import comps as comps_module
                     # Only two comparison observations have any leaf nodes that
                     # match the input observation, so make sure that the third
                     # comp is empty
-                    "comp_idx_3": [-1]
+                    "comp_idx_3": [-1],
                 },
                 dtype=np.int32,
             ),
@@ -35,11 +35,11 @@ import comps as comps_module
                     # that match the input observation
                     "comp_score_1": [0.333 * 2],
                     "comp_score_2": [0.333 * 1],
-                    "comp_score_3": [0.333 * 0]
+                    "comp_score_3": [0.333 * 0],
                 },
                 dtype=np.float32,
             ),
-            id="simple_one_observation"
+            id="simple_one_observation",
         ),
         # Extend the simple test to work with two observations to ensure
         # that the algorithm correctly prioritizes larger counts of matches
@@ -73,11 +73,11 @@ import comps as comps_module
                     "comp_score_1": [0.333 * 3] * 2,
                     "comp_score_2": [0.333 * 2] * 2,
                     "comp_score_3": [0.333 * 1] * 2,
-                    "comp_score_4": [0.333 * 0] * 2
+                    "comp_score_4": [0.333 * 0] * 2,
                 },
                 dtype=np.float32,
             ),
-            id="simple_two_observations"
+            id="simple_two_observations",
         ),
         # Test to make sure that the tree weight vector is correctly applied
         # to break ties in situations where comparison observations have the
@@ -96,14 +96,14 @@ import comps as comps_module
                 {
                     "comp_score_1": [0.5 + 0.3],
                     "comp_score_2": [0.3 + 0.2],
-                    "comp_score_3": [0.2 + 0.1]
+                    "comp_score_3": [0.2 + 0.1],
                 },
                 dtype=np.float32,
             ),
-            id="weights_tiebreak"
+            id="weights_tiebreak",
         ),
         # TODO: Test to make sure that chunking produces the correct values
-    ]
+    ],
 )
 def test_get_comps(
     leaf_nodes,


### PR DESCRIPTION
We found in https://github.com/ccao-data/model-res-avm/issues/362 that the comps pipeline was not behaving the way we expected. This problem was made worse by the fact that we didn't have any tests for the comps pipeline, so we didn't have any assurances that our assumptions about the behavior of the pipeline were true, or that they would remain unchanged as we change the comps code in subsequent PRs.

This PR adds a simple unit test suite for the `python.comps` module as a first step towards locking down the behavior of the comps pipeline. These tests ensure that the Python side of the pipeline conforms to our expectations. In a future PR, we'll want to do the same for the R side of the pipeline.