### PR TITLE
Add comps run type

### DIFF
--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -18,12 +18,13 @@ on:
         type: choice
         description: Run type or purpose
         options:
+          - baseline
+          - candidate
+          - comps
+          - final
           - junk
           - rejected
           - test
-          - baseline
-          - candidate
-          - final
         default: test
         required: true
       run_note:

--- a/.github/workflows/tag-model-runs.yaml
+++ b/.github/workflows/tag-model-runs.yaml
@@ -13,12 +13,13 @@ on:
         type: choice
         description: New/replacement run type to apply to specified runs
         options:
+          - baseline
+          - candidate
+          - comps
+          - final
           - junk
           - rejected
           - test
-          - baseline
-          - candidate
-          - final
         default: test
         required: true
       run_ids:

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -111,7 +111,8 @@ model_tag_run <- function(run_id, year, run_type) {
   paths <- model_file_dict(run_id, year)
   possible_run_types <- c(
     "junk", "rejected", "test",
-    "baseline", "candidate", "final"
+    "baseline", "candidate", "final",
+    "comps"
   )
   if (!run_type %in% possible_run_types) {
     stop(

--- a/R/setup.R
+++ b/R/setup.R
@@ -100,7 +100,8 @@ run_type <- as.character(
 # Must be one of the dedicated run types
 possible_run_types <- c(
   "junk", "rejected", "test",
-  "baseline", "candidate", "final"
+  "baseline", "candidate", "final",
+  "comps"
 )
 if (!run_type %in% possible_run_types) {
   stop(

--- a/params.yaml
+++ b/params.yaml
@@ -10,7 +10,7 @@
 # Run Control ------------------------------------------------------------------
 
 # Model tag used to identify the purpose of the run. Must be one of:
-# "junk", "rejected", "test", "baseline", "candidate", or "final"
+# "junk", "rejected", "test", "baseline", "candidate", "final", or "comps"
 run_type: "test"
 
 # Note included with each run. Use this to summarize what changed about the run


### PR DESCRIPTION
This adds comps to as a run type to 5 locations where I found text for `junk` or `rejected` in the data-architecture repository.
Once approved I can re-tag a model run as comp.