### PR TITLE
Add item to annual model issue checklist for double-checking PINVAL view columns

### DIFF
--- a/.github/ISSUE_TEMPLATE/finalize-annual-model.md
+++ b/.github/ISSUE_TEMPLATE/finalize-annual-model.md
@@ -40,6 +40,7 @@ Low priority tasks must be complete eventually, but are not time-sensitive:
 - [ ] Update the `model.final_model` seed in [`data-architecture`](https://github.com/ccao-data/data-architecture/) to include metadata for the res and condo models
 - [ ] Make sure the `vars_dict` data in [`ccao`](https://github.com/ccao-data/ccao/) is up-to-date for new features
   - If you add any features to this dictionary that are used in either model, make sure to re-knit the README for models that use the feature
+- [ ] Double check the [`pinval.vw_assessment_card`](https://github.com/ccao-data/data-architecture/blob/master/dbt/models/pinval/pinval.vw_assessment_card.sql) view to make sure any new features are selected in the output
 - [ ] Take a pass through the res model README to make sure it's up to date
   - [ ] Update the "Major Changes from Previous Versions" section to include any major changes from this year
   - [ ] Double-check that the "Features Used" table includes all features and has no missing descriptions


### PR DESCRIPTION
This small PR supports https://github.com/ccao-data/data-architecture/pull/856 by adding an item to the annual model finalization checklist to remind ourselves to update `pinval.vw_assessment_card` to select any new predictors that we added to the model.