### PR TITLE
397 add comments and example pins to help explain proration

### DIFF
--- a/pipeline/02-assess.R
+++ b/pipeline/02-assess.R
@@ -240,8 +240,8 @@ message("Prorating buildings")
 
 # They can also be part of town-home complexes (Stage 3.2). Town-home complexes
 # are grouped based on different characteristics, such as the number of rooms,
-# square footage, or proration rate, meaning tiebacks can be averaged in separate
-# groupings (tieback PINs 15213010030000 or 30171010230000)
+# square footage, or proration rate, meaning tiebacks can be averaged in
+# separate groupings (tieback PINs 15213010030000 or 30171010230000)
 
 # Prorated PINs will also be rounded in stage 3.3, meaning the averaging that
 # occurs in this and in stage 3.1 will be operating off of different values.


### PR DESCRIPTION
Tieback PINs come from the following queries. I put more specified ones regarding the individual PINs in the [‎pipeline/02-assess.R](https://github.com/ccao-data/model-res-avm/pull/404/files#diff-b48985bf2c2c82d2d3b2ccc8740edd12eb42636212386c69f6adca49190bb9c6) file. I kept the context surrounding decision making to a minimum since some of that will likely change. 

```sql
SELECT meta_tieback_key_pin,
       meta_pin_num_cards
FROM "model"."assessment_pin"
WHERE run_id = '2025-02-11-charming-eric'
  AND meta_tieback_key_pin IS NOT NULL
  AND meta_tieback_key_pin IN (
      SELECT meta_tieback_key_pin
      FROM "model"."assessment_pin"
      WHERE run_id = '2025-02-11-charming-eric'
        AND meta_tieback_key_pin IS NOT NULL
      GROUP BY meta_tieback_key_pin
      HAVING COUNT(DISTINCT meta_pin_num_cards) > 1
  )
ORDER BY meta_tieback_key_pin, meta_pin_num_cards
```

```sql
select *
from model.assessment_pin
where run_id = '2025-02-11-charming-eric'
and 
flag_land_value_capped = true
and 
meta_tieback_key_pin
 is not null
and meta_tieback_proration_rate < 1
```
```sql

SELECT meta_tieback_key_pin
FROM "model"."assessment_pin"
WHERE run_id = '2025-02-11-charming-eric'
and meta_pin_num_cards > 1
GROUP BY meta_tieback_key_pin
HAVING COUNT(DISTINCT meta_complex_id) > 1
```
```sql

SELECT
  ap.meta_tieback_key_pin,
  ap.meta_pin,
  ap.meta_pin_num_cards,
  ac.meta_card_num,
  ac.char_land_sf
FROM "model"."assessment_pin" ap
JOIN "model"."assessment_card" ac
  ON  ac.meta_pin = ap.meta_pin
  AND ac.run_id   = ap.run_id
WHERE ap.run_id = '2025-02-11-charming-eric'
  AND ap.meta_tieback_key_pin IN ('09263150040000', '09221110050000')
ORDER BY ap.meta_pin, ac.meta_card_num

```

