### PR TITLE
[Test] Don't push container images to GCHR from forks in `build-and-run-model`

### DIFF
--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -85,8 +85,9 @@ jobs:
       # required in order to allow the reusable called workflow to push to
       # GitHub Container Registry
       packages: write
-    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@main
+    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@jeancochrane/skip-ci-image-push-for-external-repos
     with:
+      ref: jeancochrane/skip-ci-image-push-for-external-repos
       command: ${{ needs.parse-command.outputs.command }}
       backend: "ec2"
       vcpu: "40"


### PR DESCRIPTION
**⚠️ This is a test PR that should be closed instead of merged. ⚠️** 

This PR tests the changes in https://github.com/ccao-data/actions/pull/40 to confirm that `build-and-run-model` **will** push container images to GCHR in PRs coming from this repo (i.e. not a fork).

See these workflow logs for evidence that the workflow did to GCHR: https://github.com/ccao-data/model-res-avm/actions/runs/19678830104/job/56367297119?pr=411