### PR TITLE
Remove class grouping follow-up

### DIFF
--- a/pipeline/00-ingest.R
+++ b/pipeline/00-ingest.R
@@ -570,7 +570,7 @@ complex_id_temp <- assessment_data_clean %>%
 # a sequential integer
 complex_id_data <- assessment_data_clean %>%
   filter(meta_class %in% c("210", "295")) %>%
-  distinct(meta_pin) %>%
+  distinct(meta_pin, meta_township_code) %>%
   left_join(complex_id_temp, by = "meta_pin") %>%
   arrange(meta_complex_id) %>%
   mutate(meta_complex_id = ifelse(


### PR DESCRIPTION
proof of run: https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_remove-stray-class-followup_ccao-data-model-res-avm%2Fdefault%2F3a1ef0e7800141d2896aeeb1be638e95

follow-up to the following PR based on a convo with Billy:
https://github.com/ccao-data/model-res-avm/pull/406