### PR TITLE
Add Exclusion Criteria for Sales to data section of README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -446,7 +446,7 @@ We accomplish these exclusions in multiple ways:
 | Deed Type | The model is trained using Warranty Deeds, Trustee Deeds, and Other deed types. Quit Claim, Executor, and Beneficial Institution may represent non-arm's-length transactions, and are excluded from the model training. | 
 | Buyer-seller attributes | The model is trained on sales between non-corporate unrelated buyers and sellers. We exclude sales between corporate affiliates, related individuals, Bank REO (Real Estate Owned), sales involving a financial institution or government agency, and sales in lieu of foreclosure. |
 
-**Analyst review.** Finally, CCAO residential analysts can manually review sales and inform us of sales that we should not use to train the model. Currently, the only sales we exclude due to analyst review are sales of homes for which an analyst finds that the square footage or age are significantly incorrect in our data
+**Analyst review.** Finally, CCAO residential analysts can manually review sales and inform us of sales that we should not use to train the model. Currently, the only sales we exclude due to analyst review are sales of homes for which an analyst finds that the square footage or age are significantly incorrect in our data.
 
 ##### Using `training_data`
 

--- a/README.md
+++ b/README.md
@@ -609,7 +609,7 @@ We accomplish these exclusions in multiple ways:
 review sales and inform us of sales that we should not use to train the
 model. Currently, the only sales we exclude due to analyst review are
 sales of homes for which an analyst finds that the square footage or age
-are significantly incorrect in our data
+are significantly incorrect in our data.
 
 ##### Using `training_data`
 


### PR DESCRIPTION
Closes Issue #416 

Note additional context / attempted data lineages:  (suggested by Nicole to exclude from public facing repo, but save somewhere- any suggestions as to where?).

## Notes

To predict the expected-market-price of unsold properties, the residential valuation model relies on (recent (within the last decade?)) sales data from across the county.  To ensure that the model is built on a data that is both accurate and representative of (true) fair- market transactions, we review all sales before including them in the model-training dataset. We remove any properties or sales outliers that may not accurately reflect fair-market transactions[^outlier_examples].  We do this with hard-coded rules (ex. deed types), statistically (ex. removing properties whose sale price is a certain number of standard deviations above the mean of properties within the same geographic area and class), and by an analyst review process (ex. checking for non-arms length sales).  
(Note: statistical, or otherwise computationally flagged outliers are (oftne, but not always) further reviewed by human analysts).

Below is a table of inclusion/exclusion criteria used by the model.  
For a brief thematic explanation of "why/how" including or excluding certain sales may alter the model's predictions, see the examples following the table.

----------------------------
|Category| Excluded (not used for model training) | Included (used for model training) | Stage and Source | Notes|
|-------|---------|--------|--------|-------|
|Muliple PINs ins sale    |multi-PIN| single-PIN| [model-ingest](https://github.com/ccao-data/model-res-avm/blob/bbc7bebc07daff3945a1df3319af44b1e57c17f6/pipeline/00-ingest.R#L114) see also this [note in sales val](https://github.com/ccao-data/model-sales-val/blob/7ad4ae8b3f1732ebaea38765e0d201a16369682c/README.md?plain=1#L51)| None|
|Single vs Multiple Buildings, single PIN | multiple buildings on single pin excluded | single building single pin | [model-training]( https://github.com/ccao-data/model-res-avm/blob/bbc7bebc07daff3945a1df3319af44b1e57c17f6/pipeline/01-train.R#L34) See here for more on [multiple buildings](https://github.com/ccao-data/wiki/blob/31f49426d6d3dd6c1741f10b04e7b0b1708bd528/Residential/Multi-Card%20PINs/multi_card_explainer.md#L4) | None |
| Year of Sale| greater than 9 years | most recent 9 years | maybe [model ingest?](https://github.com/ccao-data/model-res-avm/blob/bbc7bebc07daff3945a1df3319af44b1e57c17f6/pipeline/00-ingest.R#L111)| None |
| Sale within Same year |multiple sales of same pin within same year | single sale of single PIN | [model-ingest](https://github.com/ccao-data/model-res-avm/blob/bbc7bebc07daff3945a1df3319af44b1e57c17f6/pipeline/00-ingest.R#L115), [data-architecture](https://github.com/ccao-data/data-architecture/blob/14e5b761e2ebc6da19d671a547f526e24052efc8/dbt/models/default/docs.md?plain=1#L177)  |  this may indicate a flip (and/or may include otherwise-unrecorded-characteristic-updates)|
| Price | Less than 10k | Over 10k  | [model-ingest](https://github.com/ccao-data/model-res-avm/blob/bbc7bebc07daff3945a1df3319af44b1e57c17f6/pipeline/00-ingest.R#L116) (though see also,  for [sales-validation](https://github.com/ccao-data/model-sales-val/blob/7ad4ae8b3f1732ebaea38765e0d201a16369682c/src/00_ingest.py#L113))  | None |
| Deed Type | Quit Claim Deed, Executor Deed, Beneficial Institution, Uknown | Warranty Deeds, Trustee Deeds, Other | [model-ingest](https://github.com/ccao-data/model-res-avm/blob/bbc7bebc07daff3945a1df3319af44b1e57c17f6/pipeline/00-ingest.R#L117), or [here](https://github.com/ccao-data/model-res-avm/blob/bbc7bebc07daff3945a1df3319af44b1e57c17f6/pipeline/00-ingest.R#L113), [data-catalogue](https://github.com/ccao-data/data-architecture/blob/14e5b761e2ebc6da19d671a547f526e24052efc8/dbt/seeds/sale/sale.deed_type.csv#L1), or [data-architecture](https://github.com/ccao-data/data-architecture/blob/14e5b761e2ebc6da19d671a547f526e24052efc8/dbt/models/shared_columns.md?plain=1#L1615) | (The deed types correspond to numbers (3,4,6,99) and (1,2,5) in the data catalogue)|
| Replies to property tax form 203 | reply "yes" on any of questions 10b-10i, 10k on form 203: Sale between related individuals or corporate affiliates, Transfer of less than 100 percent interest, Court-ordered sale ,  Sale in lieu of foreclosure,  Condemnation, Short sale, Bank REO (real estate owned), Auction sale,  Seller/buyer is a financial institution or government agency | Other responses may or may not be included depending on combinations other outlier markers ([see here](https://github.com/ccao-data/model-sales-val/blob/main/README.md#what-gets-flagged))  | [203 Form from MyDec](https://tax.illinois.gov/content/dam/soi/en/web/tax/localgovernments/property/documents/ptax-203.pdf) &#8594; [Location in iAsworld table, default.vw_pin_sale, column is sale_filter_ptax_flag](https://github.com/ccao-data/data-architecture/blob/545c5a6486612992d5d32f5c49c5127fdcad8fa2/dbt/models/default/default.vw_pin_sale.sql#L207-L2107) &#8594; [modified in sales_val ingest scripts, see ptax_flag_original, _sv_individual_ptax_flag](https://github.com/ccao-data/model-sales-val/blob/ac0287a9ee872e5f5b12d55b8b3cee757372bec2/src/00_ingest.py#L93) &#8594; [integrate with other outlier criteria if needed in sales_val utils script, ultimately mark all sv_outliers](https://github.com/ccao-data/model-sales-val/blob/ac0287a9ee872e5f5b12d55b8b3cee757372bec2/src/utils.py#L102) &#8594; upload to athena &#8594; [pull data in final model ingest stage](https://github.com/ccao-data/model-res-avm/blob/master/pipeline/00-ingest.R) &#8594; [filter any remaining (203 and other) outliers pre-training](https://github.com/ccao-data/model-res-avm/blob/bbc7bebc07daff3945a1df3319af44b1e57c17f6/pipeline/01-train.R#L34)| None|
| Statistical Outliers| 2 SD above or below the mean for shared geo, class, and timeframe AND the number of similar properties of the same class, geo, and time frame [is greater than 30](https://github.com/ccao-data/model-sales-val/blob/ac0287a9ee872e5f5b12d55b8b3cee757372bec2/src/utils.py#L141C5-L145C34) | within 2SD of mean OR number of similar properties less than 30|  [Sales Validation repository readme](https://github.com/ccao-data/model-sales-val/blob/main/README.md#what-gets-flagged) | None |
 Heuristic Outliers (must be combined with a statistical outlier)  | Non-person sale, form 203 response(more than 10b?), anomaly as flagged by isolation forest, flip | (?) |   [Sales Validation repository readme](https://github.com/ccao-data/model-sales-val/blob/main/README.md#what-gets-flagged) | None|


---

 [^outlier_examples]: Useful examples of how outliers can bias the model: A property that sold for an unusually high value (for it's recorded property class, characteristics, and geography) - may reflect a recent remodel (which increased the property's sale price), whose remodeled/updated characteristics are not reflected in CCAO's characteristics data.  Conversely, an unusually low valuation for a property (relative to comparable properties in it's geo), may indicate a non-arms length transaction (ex. a sale between family members).  Both such properties should be excluded from modeling; In the first case, including the high-valued property with inaccurate characterterstics would likely inflate the modeled-values of (otherwise) similar-seeming properties, while in the second case, including the non-arms length sale with it's non-market-driven low price, would cause the model to artificially lower the predicted values of similar properties.
 
 ---

 A final note about sales inclusion criteria:  The general data ingestion process looks roughly something like this: 
 Data Integrity + Valuations and other teams at the assessor's office collect Permit Data (for characteristics, from townships), Sales data from(from sites like MyDec and the Illinois Depertmant of Revenue), and additional data &#8594; and upload this to our server (iAsworld (the assessor's office "source of truth"), see data diagram(link)). &#8594; The sales data in iAsworld is then imported into Athena (AWS), and the actual table that the model uses is default.vw_pin_sale (link to table, link to code). &#8594;  (Most of) the inclusion/exclusion filters/criteria in table above are applied either in the ingest scripts (link), or at the start of modeling (link).   That table does NOT include any inclusion/exclusion processes (or criteria) that happen prior to iAsworld ingestion (e.g. by Idor/mydec, various permitting departments, or the valuations or data integrety teams.)