### PR TITLE
Hotfix for bad neighborhood code

### DIFF
--- a/pipeline/00-ingest.R
+++ b/pipeline/00-ingest.R
@@ -153,7 +153,7 @@ tictoc::toc()
 # included in reporting and exports for a South Tri modeling year. Because this
 # is an iasWorld data issue and can't be corrected for 2025 since it's locked
 # for editing, we've decided to hard-code this correction into the pipeline for
-# now. This code should be removed for assessment year 2027 modeling.G
+# now. This code should be removed for assessment year 2027 modeling.
 assessment_data <- assessment_data %>%
   mutate(
     meta_nbhd_code = case_when(


### PR DESCRIPTION
Evidence the function works as intended:

```
> assessment_data %>% filter(meta_pin == '30172130150000') %>% pull(meta_nbhd_code)
[1] "22130" "22130"
> fix_bad_nbhd(assessment_data) %>% filter(meta_pin == '30172130150000') %>% pull(meta_nbhd_code)
[1] "37061" "37061"
```