### PR TITLE
Update training data with reviewed sales

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -5,8 +5,8 @@ stages:
     deps:
     - path: pipeline/00-ingest.R
       hash: md5
-      md5: ccf3c4f2bf27ebfc99bcc0c67cfed6e2
-      size: 23623
+      md5: 2323f973f3efa9ca6e33c9c54148e7e5
+      size: 25555
     params:
       params.yaml:
         assessment:
@@ -37,28 +37,28 @@ stages:
     outs:
     - path: input/assessment_data.parquet
       hash: md5
-      md5: 815bca22e0844c82e910d166015e5452
-      size: 418572081
+      md5: a7875fcf2f989144d5a5e4231912e5c9
+      size: 417432051
     - path: input/char_data.parquet
       hash: md5
-      md5: 8fb6173490b9e969ef9c0f2aa9a48313
-      size: 843081253
+      md5: 6c522a88942cbec76b237ade0cbc4e23
+      size: 842926898
     - path: input/complex_id_data.parquet
       hash: md5
-      md5: 425076a3e7179c93baa5f511ef71bf4b
-      size: 706109
+      md5: 81b2fc0fbbbf6cd20b3628ad07dd7fab
+      size: 704078
     - path: input/hie_data.parquet
       hash: md5
-      md5: 79d62ef4d1a9b5d945a5aafaed54e263
-      size: 1922138
+      md5: 5c871940feaff3997d105ada200e13d4
+      size: 1921054
     - path: input/land_nbhd_rate_data.parquet
       hash: md5
       md5: b4cfaf3d4a35c250990752024a88f3bb
       size: 5709
     - path: input/training_data.parquet
       hash: md5
-      md5: 9f59471e50de4f1716274f600b566db9
-      size: 197716407
+      md5: d33fcb187acabc2b7f118d1d65423a55
+      size: 197779970
   train:
     cmd: Rscript pipeline/01-train.R
     deps:
@@ -571,7 +571,8 @@ stages:
       hash: md5
       md5: 6fd4726e9b4d5686aeb5aaa559650788
       size: 8240751
-    - path: output/performance_quantile/model_performance_quantile_assessment.parquet
+    - path: 
+        output/performance_quantile/model_performance_quantile_assessment.parquet
       hash: md5
       md5: 252248672a31b8a6b3225d85aa9084e4
       size: 996286
@@ -1008,7 +1009,8 @@ stages:
           - loc_school_elementary_district_geoid
           - loc_school_secondary_district_geoid
           - loc_school_unified_district_geoid
-        run_note: Potential residential baseline with SHAP values, revert DVC path
+        run_note: Potential residential baseline with SHAP values, revert DVC 
+          path
         toggle:
           cv_enable: false
           shap_enable: true
@@ -1111,7 +1113,8 @@ stages:
       hash: md5
       md5: 6fd4726e9b4d5686aeb5aaa559650788
       size: 8240751
-    - path: output/performance_quantile/model_performance_quantile_assessment.parquet
+    - path: 
+        output/performance_quantile/model_performance_quantile_assessment.parquet
       hash: md5
       md5: 252248672a31b8a6b3225d85aa9084e4
       size: 996286


### PR DESCRIPTION
This PR reruns the ingest, pushes input data to DVC, and updates the lockfile to point to it so that we can run models using the new reviewed sales that we added in #427.

I tested this by running a model in Batch.