### PR TITLE
Update dvc lock file with fixed pace data

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -37,28 +37,28 @@ stages:
     outs:
     - path: input/assessment_data.parquet
       hash: md5
-      md5: a7875fcf2f989144d5a5e4231912e5c9
-      size: 417432051
+      md5: 823b551ed82d8cec340d3d693363b09e
+      size: 417299843
     - path: input/char_data.parquet
       hash: md5
-      md5: 6c522a88942cbec76b237ade0cbc4e23
-      size: 842926898
+      md5: d086cb9db6e6900eebd46954d37030f1
+      size: 840311240
     - path: input/complex_id_data.parquet
       hash: md5
-      md5: 81b2fc0fbbbf6cd20b3628ad07dd7fab
-      size: 704078
+      md5: 8aac5e5bfa6f92198872b510df047462
+      size: 702256
     - path: input/hie_data.parquet
       hash: md5
-      md5: 5c871940feaff3997d105ada200e13d4
-      size: 1921054
+      md5: cc1bc2cbdb518a1379cea2face520cf7
+      size: 1915072
     - path: input/land_nbhd_rate_data.parquet
       hash: md5
       md5: b4cfaf3d4a35c250990752024a88f3bb
       size: 5709
     - path: input/training_data.parquet
       hash: md5
-      md5: d33fcb187acabc2b7f118d1d65423a55
-      size: 197779970
+      md5: 9aa80ea71aee9dbcc68c8463fd6e9400
+      size: 197666751
   train:
     cmd: Rscript pipeline/01-train.R
     deps:
@@ -571,8 +571,7 @@ stages:
       hash: md5
       md5: 6fd4726e9b4d5686aeb5aaa559650788
       size: 8240751
-    - path: 
-        output/performance_quantile/model_performance_quantile_assessment.parquet
+    - path: output/performance_quantile/model_performance_quantile_assessment.parquet
       hash: md5
       md5: 252248672a31b8a6b3225d85aa9084e4
       size: 996286
@@ -1009,8 +1008,7 @@ stages:
           - loc_school_elementary_district_geoid
           - loc_school_secondary_district_geoid
           - loc_school_unified_district_geoid
-        run_note: Potential residential baseline with SHAP values, revert DVC 
-          path
+        run_note: Potential residential baseline with SHAP values, revert DVC path
         toggle:
           cv_enable: false
           shap_enable: true
@@ -1113,8 +1111,7 @@ stages:
       hash: md5
       md5: 6fd4726e9b4d5686aeb5aaa559650788
       size: 8240751
-    - path: 
-        output/performance_quantile/model_performance_quantile_assessment.parquet
+    - path: output/performance_quantile/model_performance_quantile_assessment.parquet
       hash: md5
       md5: 252248672a31b8a6b3225d85aa9084e4
       size: 996286


### PR DESCRIPTION
Just updating the lock file for a new ingest run with [fixed pace data](https://github.com/ccao-data/data-architecture/pull/987).