### PR TITLE
Make sure tag/delete model workflows can install all model dependencies

### DIFF
--- a/.github/workflows/delete-model-runs.yaml
+++ b/.github/workflows/delete-model-runs.yaml
@@ -39,7 +39,7 @@ jobs:
       # dependencies that we need to install R dependencies for the model,
       # but it's missing a handful of them
       - name: Install additional system dependencies needed for R packages
-        run: sudo apt-get install libgit2-dev libxml2-dev libglpk-dev
+        run: sudo apt-get install libgit2-dev libglpk-dev
         shell: bash
 
       - name: Disable renv sandbox to speed up install time

--- a/.github/workflows/tag-model-runs.yaml
+++ b/.github/workflows/tag-model-runs.yaml
@@ -52,7 +52,7 @@ jobs:
       # dependencies that we need to install R dependencies for the model,
       # but it's missing a handful of them
       - name: Install additional system dependencies needed for R packages
-        run: sudo apt-get install libgit2-dev libxml2-dev libglpk-dev
+        run: sudo apt-get install libgit2-dev libglpk-dev
         shell: bash
 
       - name: Disable renv sandbox to speed up install time


### PR DESCRIPTION
I noticed while attempting to tag the 2026 final res model run that [igraph is failing to install](https://github.com/ccao-data/model-res-avm/actions/runs/21926552587/job/63555752679#step:6:510) during the workflow build step:

```
Error in dyn.load(file, DLLpath = DLLpath, ...) : 
  unable to load shared object '/home/runner/work/model-res-avm/model-res-avm/renv/staging/1/igraph/libs/igraph.so':
  libglpk.so.40: cannot open shared object file: No such file or directory
Calls: loadNamespace -> library.dynam -> dyn.load
Execution halted
```

Per the [igraph docs](https://r.igraph.org/), `libglpk-dev` is a required system dependency for igraph. We switched igraph from a dev dependency to a top-level dependency when we started using it to infer tieback cycles in https://github.com/ccao-data/model-res-avm/pull/434, so now the tag and delete workflows will need to install it along with the rest of the model's top-level R dependencies. This PR updates those workflow definitions to make sure `libglpk-dev` is installed.

As a side note: Package discrepancies like this one are likely to continue to occur as long as these two workflows install their own system dependencies instead of using the Dockerfile that we use to build the model containers for use on Batch. In the long term, we should probably switch these workflows to run in a container that we build from that Dockerfile. For now, I just want to get this fix over the line, so I'm going with the fast + easy solution and manually updating the dependency list for both of the workflows, since it takes some time and effort to properly containerize GitHub workflows like these ones. I opened up https://github.com/ccao-data/model-res-avm/issues/445 to track the longer-term fix of moving these workflows to containerized environments.

See here for a test run confirming that the fix works for the `tag-model-runs` workflow: https://github.com/ccao-data/model-res-avm/actions/runs/21997637579/job/63561720817

And here is a test run for the `delete-model-runs` workflow: https://github.com/ccao-data/model-res-avm/actions/runs/22106811741