### PR TITLE
Add Tim to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @wrridgeway @jeancochrane
+* @wrridgeway @jeancochrane @TimCookCountyDS


### PR DESCRIPTION
This PR adds @TimCookCountyDS to the `CODEOWNERS` file so that Tim can approve PRs.