### PR TITLE
Update Python test workflow to ensure we install dependencies from uv lockfile

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ name: test
 
 env:
   PYTHONUNBUFFERED: "1"
-  UV_SYSTEM_PYTHON: 1
+  UV_FROZEN: 1
 
 jobs:
   test:
@@ -33,9 +33,9 @@ jobs:
       - name: Install dependencies
         working-directory: python
         shell: bash
-        run: uv pip install .[tests]
+        run: uv sync --extra tests
 
       - name: Run Python tests
         shell: bash
         working-directory: python
-        run: pytest
+        run: uv run pytest


### PR DESCRIPTION
As we found in https://github.com/ccao-data/homeval/pull/158, the way we use `uv pip install` in the `test` workflow in this repo will cause uv to ignore `python/uv.lock` when installing dependencies. Instead, uv will decide which dependency versions to install based on the contents of `python/pyproject.toml`, but the dependencies in that config file are not locked to specific versions and hashes like they are in `python/uv.lock`.

This PR updates the `test` workflow that runs our Python tests to use uv commands that will ensure we use the exact versions of packages pinned in `python/uv.lock`. We don't need to update the modeling pipeline itself to use different commands because we use the reticulate uv integration to manage Python dependencies for us. This code has a bit more background:

https://github.com/ccao-data/model-res-avm/blob/3cbee466261aadb6350f067685193060b73d3324/pipeline/04-interpret.R#L12-L25

Unfortunately, this means that reticulate won't use `python/uv.lock` either. However, this is [the recommended way of using the reticulate uv integration](https://posit.co/blog/reticulate-1-41), and [`py_require` doesn't include an option to respect a lockfile](https://rstudio.github.io/reticulate/reference/py_require.html), so we would need to roll our own solution to start using the lockfile. I think it's better to use the first-party reticulate uv integration and accept the possibility of different package patch versions than it is to roll our own solution and lock down exact package versions, but I'm open to pushback on that decision.

We don't need a corresponding condo PR for this res PR because the condo PR doesn't have any Python code, so it doesn't use uv.