### PR TITLE
Add param for stratified test set

### DIFF
--- a/params.yaml
+++ b/params.yaml
@@ -110,6 +110,11 @@ cv:
   # 0.9 means the most recent 10% of sales are used as a test set
   split_prop: 0.9
 
+  # The stratified test set selects a random percentage of sales, grouped by
+  # township, year, and month to add to the test set. If this is set to 0,
+  # it has not impact on the pipeline.
+  stratified_test_set: 0
+
   # Number of folds to use for cross-validation. For v-fold CV, the data will be
   # randomly split. For rolling-origin, the data will be split into V chunks by
   # time, with each chunk/period calculated automatically

--- a/params.yaml
+++ b/params.yaml
@@ -105,7 +105,7 @@ input:
   # township, year, and month to add to the test set. If this is set to 0,
   # it has not impact on the pipeline.
   additional_test_set:
-    stratified_prop: .05
+    stratified_prop: .00
 
 
 # Cross-validation -------------------------------------------------------------

--- a/params.yaml
+++ b/params.yaml
@@ -105,7 +105,7 @@ input:
   # township, year, and month to add to the test set. If this is set to 0,
   # it has not impact on the pipeline.
   test_set:
-    stratified_prop: 0
+    stratified_prop: 5
 
 
 # Cross-validation -------------------------------------------------------------

--- a/params.yaml
+++ b/params.yaml
@@ -104,7 +104,7 @@ input:
   # A stratified test set selects a random percentage of sales, grouped by
   # township, year, and month to add to the test set. If this is set to 0,
   # it has not impact on the pipeline.
-  test_set:
+  additional_test_set:
     stratified_prop: 5
 
 

--- a/params.yaml
+++ b/params.yaml
@@ -101,6 +101,12 @@ input:
     # Fraction of the training data to keep (between 0 and 1)
     fraction: 0.25
 
+  # A stratified test set selects a random percentage of sales, grouped by
+  # township, year, and month to add to the test set. If this is set to 0,
+  # it has not impact on the pipeline.
+  test_set:
+    stratified_prop: 0
+
 
 # Cross-validation -------------------------------------------------------------
 
@@ -110,10 +116,6 @@ cv:
   # 0.9 means the most recent 10% of sales are used as a test set
   split_prop: 0.9
 
-  # The stratified test set selects a random percentage of sales, grouped by
-  # township, year, and month to add to the test set. If this is set to 0,
-  # it has not impact on the pipeline.
-  stratified_test_set: 0
 
   # Number of folds to use for cross-validation. For v-fold CV, the data will be
   # randomly split. For rolling-origin, the data will be split into V chunks by

--- a/params.yaml
+++ b/params.yaml
@@ -105,7 +105,7 @@ input:
   # township, year, and month to add to the test set. If this is set to 0,
   # it has not impact on the pipeline.
   additional_test_set:
-    stratified_prop: 5
+    stratified_prop: .05
 
 
 # Cross-validation -------------------------------------------------------------

--- a/params.yaml
+++ b/params.yaml
@@ -116,7 +116,6 @@ cv:
   # 0.9 means the most recent 10% of sales are used as a test set
   split_prop: 0.9
 
-
   # Number of folds to use for cross-validation. For v-fold CV, the data will be
   # randomly split. For rolling-origin, the data will be split into V chunks by
   # time, with each chunk/period calculated automatically

--- a/params.yaml
+++ b/params.yaml
@@ -112,7 +112,7 @@ cv:
 
   # A stratified test set selects a random percentage of sales, grouped by
   # township, year, and month to add to the test set. If this is set to 0,
-  # it has not impact on the pipeline.
+  # it has no impact on the pipeline.
   stratified_prop: .05
 
   # Number of folds to use for cross-validation. For v-fold CV, the data will be

--- a/params.yaml
+++ b/params.yaml
@@ -113,7 +113,7 @@ cv:
   # A stratified test set selects a random percentage of sales, grouped by
   # township, year, and month to add to the test set. If this is set to 0,
   # it has no impact on the pipeline.
-  stratified_prop: .05
+  stratified_prop: 0.00
 
   # Number of folds to use for cross-validation. For v-fold CV, the data will be
   # randomly split. For rolling-origin, the data will be split into V chunks by

--- a/params.yaml
+++ b/params.yaml
@@ -101,12 +101,6 @@ input:
     # Fraction of the training data to keep (between 0 and 1)
     fraction: 0.25
 
-  # A stratified test set selects a random percentage of sales, grouped by
-  # township, year, and month to add to the test set. If this is set to 0,
-  # it has not impact on the pipeline.
-  additional_test_set:
-    stratified_prop: .00
-
 
 # Cross-validation -------------------------------------------------------------
 
@@ -115,6 +109,11 @@ cv:
   # Proportion of the training data to use for training vs test, split by time.
   # 0.9 means the most recent 10% of sales are used as a test set
   split_prop: 0.9
+
+  # A stratified test set selects a random percentage of sales, grouped by
+  # township, year, and month to add to the test set. If this is set to 0,
+  # it has not impact on the pipeline.
+  stratified_prop: .00
 
   # Number of folds to use for cross-validation. For v-fold CV, the data will be
   # randomly split. For rolling-origin, the data will be split into V chunks by

--- a/params.yaml
+++ b/params.yaml
@@ -113,7 +113,7 @@ cv:
   # A stratified test set selects a random percentage of sales, grouped by
   # township, year, and month to add to the test set. If this is set to 0,
   # it has not impact on the pipeline.
-  stratified_prop: .00
+  stratified_prop: .05
 
   # Number of folds to use for cross-validation. For v-fold CV, the data will be
   # randomly split. For rolling-origin, the data will be split into V chunks by

--- a/pipeline/01-train.R
+++ b/pipeline/01-train.R
@@ -44,6 +44,20 @@ split_data <- initial_time_split(
 test <- testing(split_data)
 train <- training(split_data)
 
+# Add a stratified test set which is only included if the value is not set to 0
+# This will take a random selection of sales grouped by township,
+# month, and year and add them to `test`.
+if (params$cv$stratified_test_set != 0) {
+  test <- bind_rows(
+    test,
+    train %>%
+      group_by(meta_township_code, time_sale_year, time_sale_month_of_year) %>%
+      slice_sample(prop = params$cv$stratified_test_set) %>%
+      ungroup()
+  )
+  train <- anti_join(train, test, by = names(train))
+}
+
 # Create a recipe for the training data which removes non-predictor columns and
 # preps categorical data, see R/recipes.R for details
 train_recipe <- model_main_recipe(

--- a/pipeline/01-train.R
+++ b/pipeline/01-train.R
@@ -47,12 +47,12 @@ train <- training(split_data)
 # Add a stratified test set which is only included if the value is not set to 0
 # This will take a random selection of sales grouped by township,
 # month, and year and add them to `test`.
-if (params$cv$stratified_test_set != 0) {
+if (params$test_set$stratified_prop != 0) {
   test <- bind_rows(
     test,
     train %>%
       group_by(meta_township_code, time_sale_year, time_sale_month_of_year) %>%
-      slice_sample(prop = params$cv$stratified_test_set) %>%
+      slice_sample(prop = test_set$stratified_prop) %>%
       ungroup()
   )
   train <- anti_join(train, test, by = names(train))

--- a/pipeline/01-train.R
+++ b/pipeline/01-train.R
@@ -47,10 +47,10 @@ train <- training(split_data)
 # Add a stratified test set which is only included if the value is not set to 0
 # This will take a random selection of sales grouped by township,
 # month, and year and add them to `test`.
-if (params$input$test_set$stratified_prop != 0) {
+if (params$input$additional_test_set$stratified_prop != 0) {
   stratified_sample <- train %>%
     group_by(meta_township_code, time_sale_year, time_sale_month_of_year) %>%
-    slice_sample(prop = params$input$test_set$stratified_prop) %>%
+    slice_sample(prop = params$input$additional_test_set$stratified_prop) %>%
     ungroup()
 
   test <- bind_rows(test, stratified_sample)

--- a/pipeline/01-train.R
+++ b/pipeline/01-train.R
@@ -47,15 +47,14 @@ train <- training(split_data)
 # Add a stratified test set which is only included if the value is not set to 0
 # This will take a random selection of sales grouped by township,
 # month, and year and add them to `test`.
-if (params$test_set$stratified_prop != 0) {
-  test <- bind_rows(
-    test,
-    train %>%
-      group_by(meta_township_code, time_sale_year, time_sale_month_of_year) %>%
-      slice_sample(prop = test_set$stratified_prop) %>%
-      ungroup()
-  )
-  train <- anti_join(train, test, by = names(train))
+if (params$input$test_set$stratified_prop != 0) {
+  stratified_sample <- train %>%
+    group_by(meta_township_code, time_sale_year, time_sale_month_of_year) %>%
+    slice_sample(prop = params$input$test_set$stratified_prop) %>%
+    ungroup()
+
+  test <- bind_rows(test, stratified_sample)
+  train <- anti_join(train, stratified_sample, by = "meta_sale_document_num")
 }
 
 # Create a recipe for the training data which removes non-predictor columns and

--- a/pipeline/01-train.R
+++ b/pipeline/01-train.R
@@ -56,7 +56,8 @@ if (params$cv$stratified_prop != 0) {
     initial_split(
       prop = 1 - params$cv$stratified_prop,
       strata = .strat
-    )  %>% select(-.strat)
+    ) %>%
+    select(-.strat)
 
   train <- training(strat_split)
   stratified_sample <- testing(strat_split)

--- a/pipeline/01-train.R
+++ b/pipeline/01-train.R
@@ -56,10 +56,10 @@ if (params$cv$stratified_prop != 0) {
     initial_split(
       prop = 1 - params$cv$stratified_prop,
       strata = .strat
-    )
+    )  %>% select(-.strat)
 
-  train <- training(strat_split) %>% select(-.strat)
-  stratified_sample <- testing(strat_split) %>% select(-.strat)
+  train <- training(strat_split)
+  stratified_sample <- testing(strat_split)
   test <- bind_rows(test, stratified_sample)
 }
 

--- a/pipeline/01-train.R
+++ b/pipeline/01-train.R
@@ -47,14 +47,20 @@ train <- training(split_data)
 # Add a stratified test set which is only included if the value is not set to 0
 # This will take a random selection of sales grouped by township,
 # month, and year and add them to `test`.
-if (params$input$additional_test_set$stratified_prop != 0) {
-  stratified_sample <- train %>%
-    group_by(meta_township_code, time_sale_year, time_sale_month_of_year) %>%
-    slice_sample(prop = params$input$additional_test_set$stratified_prop) %>%
-    ungroup()
+if (params$cv$stratified_prop != 0) {
+  strat_split <- train %>%
+    mutate(.strat = interaction(
+      meta_township_code, time_sale_year, time_sale_month_of_year,
+      drop = TRUE
+    )) %>%
+    initial_split(
+      prop = 1 - params$cv$stratified_prop,
+      strata = .strat
+    )
 
+  train <- training(strat_split) %>% select(-.strat)
+  stratified_sample <- testing(strat_split) %>% select(-.strat)
   test <- bind_rows(test, stratified_sample)
-  train <- anti_join(train, stratified_sample, by = "meta_sale_document_num")
 }
 
 # Create a recipe for the training data which removes non-predictor columns and

--- a/pipeline/05-finalize.R
+++ b/pipeline/05-finalize.R
@@ -85,7 +85,8 @@ metadata <- tibble::tibble(
   input_sale_validation_dev_bounds = list(
     params$input$sale_validation$dev_bounds
   ),
-  input_test_set_stratified_prop = params$test_set$stratified_prop,
+  input_additional_test_set_stratified_prop =
+    params$input$additional_test_set$stratified_prop,
   ratio_study_far_year = params$ratio_study$far_year,
   ratio_study_far_stage = params$ratio_study$far_stage,
   ratio_study_far_column = params$ratio_study$far_column,

--- a/pipeline/05-finalize.R
+++ b/pipeline/05-finalize.R
@@ -85,6 +85,7 @@ metadata <- tibble::tibble(
   input_sale_validation_dev_bounds = list(
     params$input$sale_validation$dev_bounds
   ),
+  input_test_set_stratified_prop = params$test_set$stratified_prop,
   ratio_study_far_year = params$ratio_study$far_year,
   ratio_study_far_stage = params$ratio_study$far_stage,
   ratio_study_far_column = params$ratio_study$far_column,

--- a/pipeline/05-finalize.R
+++ b/pipeline/05-finalize.R
@@ -85,8 +85,6 @@ metadata <- tibble::tibble(
   input_sale_validation_dev_bounds = list(
     params$input$sale_validation$dev_bounds
   ),
-  input_additional_test_set_stratified_prop =
-    params$input$additional_test_set$stratified_prop,
   ratio_study_far_year = params$ratio_study$far_year,
   ratio_study_far_stage = params$ratio_study$far_stage,
   ratio_study_far_column = params$ratio_study$far_column,
@@ -104,6 +102,7 @@ metadata <- tibble::tibble(
   cv_initial_set = params$cv$initial_set,
   cv_max_iterations = params$cv$max_iterations,
   cv_no_improve = params$cv$no_improve,
+  cv_stratified_prop = params$cv$stratified_prop,
   cv_split_prop = params$cv$split_prop,
   cv_best_metric = params$cv$best_metric,
   pv_land_pct_of_total_cap = params$pv$land_pct_of_total_cap,

--- a/reports/_setup.R
+++ b/reports/_setup.R
@@ -236,7 +236,8 @@ m_test_split_prop <- scales::percent(
   accuracy = 0.01
 )
 m_test_split_stratified_prop <- scales::percent(
-  as.numeric(metadata$input_additional_test_set_stratified_prop)
+  as.numeric(metadata$input_additional_test_set_stratified_prop),
+  accuracy = 0.01
 )
 m_train_min_date <- min(training_data$meta_sale_date)
 m_train_max_date <- max(training_data$meta_sale_date)

--- a/reports/_setup.R
+++ b/reports/_setup.R
@@ -236,7 +236,7 @@ m_test_split_prop <- scales::percent(
   accuracy = 0.01
 )
 m_test_split_stratified_prop <- scales::percent(
-  metadata$input_additional_test_set_stratified_prop
+  as.numeric(metadata$input_additional_test_set_stratified_prop)
 )
 m_train_min_date <- min(training_data$meta_sale_date)
 m_train_max_date <- max(training_data$meta_sale_date)

--- a/reports/_setup.R
+++ b/reports/_setup.R
@@ -235,7 +235,9 @@ m_test_split_prop <- scales::percent(
   1 - metadata$cv_split_prop,
   accuracy = 0.01
 )
-
+m_test_split_stratified_prop <- scales::percent(
+  metadata$input_additional_test_set_stratified_prop
+)
 m_train_min_date <- min(training_data$meta_sale_date)
 m_train_max_date <- max(training_data$meta_sale_date)
 m_train_n_sales <- training_data %>%

--- a/reports/_setup.R
+++ b/reports/_setup.R
@@ -236,7 +236,7 @@ m_test_split_prop <- scales::percent(
   accuracy = 0.01
 )
 m_test_split_stratified_prop <- scales::percent(
-  as.numeric(metadata$cv$stratified_prop),
+  as.numeric(metadata$cv_stratified_prop),
   accuracy = 0.01
 )
 m_train_min_date <- min(training_data$meta_sale_date)

--- a/reports/_setup.R
+++ b/reports/_setup.R
@@ -236,7 +236,7 @@ m_test_split_prop <- scales::percent(
   accuracy = 0.01
 )
 m_test_split_stratified_prop <- scales::percent(
-  as.numeric(metadata$input_additional_test_set_stratified_prop),
+  as.numeric(metadata$cv$stratified_prop),
   accuracy = 0.01
 )
 m_train_min_date <- min(training_data$meta_sale_date)

--- a/reports/performance/_model.qmd
+++ b/reports/performance/_model.qmd
@@ -26,7 +26,7 @@ The following document describes performance for ```r metadata$run_id```, a ```r
   - Spanned from ```r m_test_min_date``` to ```r m_test_max_date```
   - Contained ```r m_test_n_sales``` total sales, of which ```r m_test_n_sales_triad``` (```r m_test_n_sales_prop```) were in the ```r metadata$assessment_triad``` triad
   - Had a median sale price of ```r m_test_med_sp```
-  - Included the last ```r m_test_split_prop``` of all training data sales`r if (metadata$input$additional_test_set$stratified_prop != 0) paste0(", and a stratified ", scales::percent(metadata$input$additional_test_set$stratified_prop), " sample of all remaining sales grouped by township, month, and year")`
+  - Included the last ```r m_test_split_prop``` of all training data sales`r if (m_test_split_stratified_prop != 0) paste0(", and a stratified ", scales::percent(m_test_split_stratified_prop), " sample of all remaining sales grouped by township, month, and year")`
   - **Training Set**: Full data used to train to model for final prediction (prediction on the assessment set, not the test set). This _includes_ the test set, which is removed during model cross-validation and tuning. For this run, the training set:
   - Spanned from ```r m_train_min_date``` to ```r m_train_max_date```
   - Contained ```r m_train_n_sales``` total sales, of which ```r m_train_n_sales_triad``` (```r m_train_n_sales_prop```) were in the ```r metadata$assessment_triad``` triad

--- a/reports/performance/_model.qmd
+++ b/reports/performance/_model.qmd
@@ -27,6 +27,7 @@ The following document describes performance for ```r metadata$run_id```, a ```r
   - Contained ```r m_test_n_sales``` total sales, of which ```r m_test_n_sales_triad``` (```r m_test_n_sales_prop```) were in the ```r metadata$assessment_triad``` triad
   - Had a median sale price of ```r m_test_med_sp```
   - Included the last ```r m_test_split_prop``` of all training data sales
+`r if (metadata$test_set$stratified_prop != 0) paste0("\n\n  - Included a stratified ", m_test_stratified_prop, " sample of all remaining sales, grouped by township, month, and year")`
 - **Training Set**: Full data used to train to model for final prediction (prediction on the assessment set, not the test set). This _includes_ the test set, which is removed during model cross-validation and tuning. For this run, the training set:
   - Spanned from ```r m_train_min_date``` to ```r m_train_max_date```
   - Contained ```r m_train_n_sales``` total sales, of which ```r m_train_n_sales_triad``` (```r m_train_n_sales_prop```) were in the ```r metadata$assessment_triad``` triad

--- a/reports/performance/_model.qmd
+++ b/reports/performance/_model.qmd
@@ -26,7 +26,7 @@ The following document describes performance for ```r metadata$run_id```, a ```r
   - Spanned from ```r m_test_min_date``` to ```r m_test_max_date```
   - Contained ```r m_test_n_sales``` total sales, of which ```r m_test_n_sales_triad``` (```r m_test_n_sales_prop```) were in the ```r metadata$assessment_triad``` triad
   - Had a median sale price of ```r m_test_med_sp```
-  - Included the last ```r m_test_split_prop``` of all training data sales`r if (metadata$input$test_set$stratified_prop != 0) paste0(", and a stratified ", scales::percent(metadata$input$test_set$stratified_prop), " sample of all remaining sales grouped by township, month, and year")`
+  - Included the last ```r m_test_split_prop``` of all training data sales`r if (metadata$input$additional_test_set$stratified_prop != 0) paste0(", and a stratified ", scales::percent(metadata$input$additional_test_set$stratified_prop), " sample of all remaining sales grouped by township, month, and year")`
   - **Training Set**: Full data used to train to model for final prediction (prediction on the assessment set, not the test set). This _includes_ the test set, which is removed during model cross-validation and tuning. For this run, the training set:
   - Spanned from ```r m_train_min_date``` to ```r m_train_max_date```
   - Contained ```r m_train_n_sales``` total sales, of which ```r m_train_n_sales_triad``` (```r m_train_n_sales_prop```) were in the ```r metadata$assessment_triad``` triad

--- a/reports/performance/_model.qmd
+++ b/reports/performance/_model.qmd
@@ -26,8 +26,8 @@ The following document describes performance for ```r metadata$run_id```, a ```r
   - Spanned from ```r m_test_min_date``` to ```r m_test_max_date```
   - Contained ```r m_test_n_sales``` total sales, of which ```r m_test_n_sales_triad``` (```r m_test_n_sales_prop```) were in the ```r metadata$assessment_triad``` triad
   - Had a median sale price of ```r m_test_med_sp```
-  - Included the last ```r m_test_split_prop``` of all training data sales`r if (m_test_split_stratified_prop != 0) paste0(", and a stratified ", scales::percent(m_test_split_stratified_prop), " sample of all remaining sales grouped by township, month, and year")`
-  - **Training Set**: Full data used to train to model for final prediction (prediction on the assessment set, not the test set). This _includes_ the test set, which is removed during model cross-validation and tuning. For this run, the training set:
+  - Included the last `r m_test_split_prop` of all training data sales`r if (isTRUE(m_test_split_stratified_prop != "0%")) paste0(", and a stratified ", m_test_split_stratified_prop, " sample of all remaining sales grouped by township, month, and year")`
+- **Training Set**: Full data used to train to model for final prediction (prediction on the assessment set, not the test set). This _includes_ the test set, which is removed during model cross-validation and tuning. For this run, the training set:
   - Spanned from ```r m_train_min_date``` to ```r m_train_max_date```
   - Contained ```r m_train_n_sales``` total sales, of which ```r m_train_n_sales_triad``` (```r m_train_n_sales_prop```) were in the ```r metadata$assessment_triad``` triad
   - Had a median sale price of ```r m_train_med_sp```

--- a/reports/performance/_model.qmd
+++ b/reports/performance/_model.qmd
@@ -26,9 +26,8 @@ The following document describes performance for ```r metadata$run_id```, a ```r
   - Spanned from ```r m_test_min_date``` to ```r m_test_max_date```
   - Contained ```r m_test_n_sales``` total sales, of which ```r m_test_n_sales_triad``` (```r m_test_n_sales_prop```) were in the ```r metadata$assessment_triad``` triad
   - Had a median sale price of ```r m_test_med_sp```
-  - Included the last ```r m_test_split_prop``` of all training data sales
-`r if (metadata$test_set$stratified_prop != 0) paste0("\n\n  - Included a stratified ", m_test_stratified_prop, " sample of all remaining sales, grouped by township, month, and year")`
-- **Training Set**: Full data used to train to model for final prediction (prediction on the assessment set, not the test set). This _includes_ the test set, which is removed during model cross-validation and tuning. For this run, the training set:
+  - Included the last ```r m_test_split_prop``` of all training data sales`r if (metadata$input$test_set$stratified_prop != 0) paste0(", and a stratified ", scales::percent(metadata$input$test_set$stratified_prop), " sample of all remaining sales grouped by township, month, and year")`
+  - **Training Set**: Full data used to train to model for final prediction (prediction on the assessment set, not the test set). This _includes_ the test set, which is removed during model cross-validation and tuning. For this run, the training set:
   - Spanned from ```r m_train_min_date``` to ```r m_train_max_date```
   - Contained ```r m_train_n_sales``` total sales, of which ```r m_train_n_sales_triad``` (```r m_train_n_sales_prop```) were in the ```r metadata$assessment_triad``` triad
   - Had a median sale price of ```r m_train_med_sp```

--- a/reports/performance/_model.qmd
+++ b/reports/performance/_model.qmd
@@ -26,7 +26,7 @@ The following document describes performance for ```r metadata$run_id```, a ```r
   - Spanned from ```r m_test_min_date``` to ```r m_test_max_date```
   - Contained ```r m_test_n_sales``` total sales, of which ```r m_test_n_sales_triad``` (```r m_test_n_sales_prop```) were in the ```r metadata$assessment_triad``` triad
   - Had a median sale price of ```r m_test_med_sp```
-  - Included the last `r m_test_split_prop` of all training data sales`r if (isTRUE(m_test_split_stratified_prop != "0%")) paste0(", and a stratified ", m_test_split_stratified_prop, " sample of all remaining sales grouped by township, month, and year")`
+  - Included the last `r m_test_split_prop` of all training data sales`r if (isTRUE(m_test_split_stratified_prop != "0.00%")) { paste0(", and a stratified ", m_test_split_stratified_prop, " sample of all remaining sales grouped by township, month, and year") }`
 - **Training Set**: Full data used to train to model for final prediction (prediction on the assessment set, not the test set). This _includes_ the test set, which is removed during model cross-validation and tuning. For this run, the training set:
   - Spanned from ```r m_train_min_date``` to ```r m_train_max_date```
   - Contained ```r m_train_n_sales``` total sales, of which ```r m_train_n_sales_triad``` (```r m_train_n_sales_prop```) were in the ```r metadata$assessment_triad``` triad

--- a/reports/performance/_model.qmd
+++ b/reports/performance/_model.qmd
@@ -26,7 +26,7 @@ The following document describes performance for ```r metadata$run_id```, a ```r
   - Spanned from ```r m_test_min_date``` to ```r m_test_max_date```
   - Contained ```r m_test_n_sales``` total sales, of which ```r m_test_n_sales_triad``` (```r m_test_n_sales_prop```) were in the ```r metadata$assessment_triad``` triad
   - Had a median sale price of ```r m_test_med_sp```
-  - Included the last `r m_test_split_prop` of all training data sales`r if (isTRUE(m_test_split_stratified_prop != "0.00%")) { paste0(", and a stratified ", m_test_split_stratified_prop, " sample of all remaining sales grouped by township, month, and year") }`
+  - Included the last ```r m_test_split_prop``` of all training data sales`r if (isTRUE(m_test_split_stratified_prop != "0.00%")) { paste0(", and a stratified ", ```m_test_split_stratified_prop```, " sample of all remaining sales grouped by township, month, and year") }`
 - **Training Set**: Full data used to train to model for final prediction (prediction on the assessment set, not the test set). This _includes_ the test set, which is removed during model cross-validation and tuning. For this run, the training set:
   - Spanned from ```r m_train_min_date``` to ```r m_train_max_date```
   - Contained ```r m_train_n_sales``` total sales, of which ```r m_train_n_sales_triad``` (```r m_train_n_sales_prop```) were in the ```r metadata$assessment_triad``` triad

--- a/reports/performance/_model.qmd
+++ b/reports/performance/_model.qmd
@@ -26,7 +26,7 @@ The following document describes performance for ```r metadata$run_id```, a ```r
   - Spanned from ```r m_test_min_date``` to ```r m_test_max_date```
   - Contained ```r m_test_n_sales``` total sales, of which ```r m_test_n_sales_triad``` (```r m_test_n_sales_prop```) were in the ```r metadata$assessment_triad``` triad
   - Had a median sale price of ```r m_test_med_sp```
-  - Included the last ```r m_test_split_prop``` of all training data sales`r if (isTRUE(m_test_split_stratified_prop != "0.00%")) { paste0(", and a stratified `", m_test_split_stratified_prop, "` sample of all remaining sales grouped by township, month, and year") }`
+  - Included the last ```r m_test_split_prop``` of all training data sales`r if (isTRUE(m_test_split_stratified_prop != "0.00%")) { paste0(", and a stratified <code>", m_test_split_stratified_prop, "</code> sample of all remaining sales grouped by township, month, and year") }`
 - **Training Set**: Full data used to train to model for final prediction (prediction on the assessment set, not the test set). This _includes_ the test set, which is removed during model cross-validation and tuning. For this run, the training set:
   - Spanned from ```r m_train_min_date``` to ```r m_train_max_date```
   - Contained ```r m_train_n_sales``` total sales, of which ```r m_train_n_sales_triad``` (```r m_train_n_sales_prop```) were in the ```r metadata$assessment_triad``` triad

--- a/reports/performance/_model.qmd
+++ b/reports/performance/_model.qmd
@@ -26,7 +26,7 @@ The following document describes performance for ```r metadata$run_id```, a ```r
   - Spanned from ```r m_test_min_date``` to ```r m_test_max_date```
   - Contained ```r m_test_n_sales``` total sales, of which ```r m_test_n_sales_triad``` (```r m_test_n_sales_prop```) were in the ```r metadata$assessment_triad``` triad
   - Had a median sale price of ```r m_test_med_sp```
-  - Included the last ```r m_test_split_prop``` of all training data sales`r if (isTRUE(m_test_split_stratified_prop != "0.00%")) { paste0(", and a stratified ", ```m_test_split_stratified_prop```, " sample of all remaining sales grouped by township, month, and year") }`
+  - Included the last ```r m_test_split_prop``` of all training data sales`r if (isTRUE(m_test_split_stratified_prop != "0.00%")) { paste0(", and a stratified `", m_test_split_stratified_prop, "` sample of all remaining sales grouped by township, month, and year") }`
 - **Training Set**: Full data used to train to model for final prediction (prediction on the assessment set, not the test set). This _includes_ the test set, which is removed during model cross-validation and tuning. For this run, the training set:
   - Spanned from ```r m_train_min_date``` to ```r m_train_max_date```
   - Contained ```r m_train_n_sales``` total sales, of which ```r m_train_n_sales_triad``` (```r m_train_n_sales_prop```) were in the ```r metadata$assessment_triad``` triad

--- a/reports/performance/_model.qmd
+++ b/reports/performance/_model.qmd
@@ -26,7 +26,7 @@ The following document describes performance for ```r metadata$run_id```, a ```r
   - Spanned from ```r m_test_min_date``` to ```r m_test_max_date```
   - Contained ```r m_test_n_sales``` total sales, of which ```r m_test_n_sales_triad``` (```r m_test_n_sales_prop```) were in the ```r metadata$assessment_triad``` triad
   - Had a median sale price of ```r m_test_med_sp```
-  - Included the last ```r m_test_split_prop``` of all training data sales`r if (isTRUE(m_test_split_stratified_prop != "0.00%")) { paste0(", and a stratified <code>", m_test_split_stratified_prop, "</code> sample of all remaining sales grouped by township, month, and year") }`
+  - Included the most recent ```r m_test_split_prop``` of all training data sales`r if (isTRUE(m_test_split_stratified_prop != "0.00%")) { paste0(", and a stratified <code>", m_test_split_stratified_prop, "</code> sample of all remaining sales grouped by township, month, and year") }`
 - **Training Set**: Full data used to train to model for final prediction (prediction on the assessment set, not the test set). This _includes_ the test set, which is removed during model cross-validation and tuning. For this run, the training set:
   - Spanned from ```r m_train_min_date``` to ```r m_train_max_date```
   - Contained ```r m_train_n_sales``` total sales, of which ```r m_train_n_sales_triad``` (```r m_train_n_sales_prop```) were in the ```r metadata$assessment_triad``` triad


### PR DESCRIPTION
Based on the output of https://github.com/ccao-data/enterprise-intelligence/pull/442, we are adding a param for a stratified test set. This is defined as a random percentage of sales grouped by township, month, and year. When set to 0, it will not have any impact on the pipeline. 

run_id = `2026-05-19-quirky-maya` - count of test set is `36,729`

Example of performance report with param set to 0.

<img width="804" height="155" alt="image" src="https://github.com/user-attachments/assets/0f92df74-f445-42b9-a788-2c09fb83dadf" />



run_id: `2026-05-19-quirky-maya `- count of test set is `51,544`

Example of performance report with param set to .05

<img width="790" height="174" alt="image" src="https://github.com/user-attachments/assets/86616286-cb22-4bf0-9df9-8e4bd8f2785e" />

I'll rerun the report with ``` ``` once the review is done just to make sure the values are back in quotes.

It also produces a column in model.metadata called input_additional_test_set_stratified_prop.