### PR TITLE
Upgrade all third-party actions and pin them to immutable releases

### DIFF
--- a/.github/workflows/delete-model-runs.yaml
+++ b/.github/workflows/delete-model-runs.yaml
@@ -28,10 +28,10 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repo code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e
         with:
           use-public-rspm: true
 
@@ -47,10 +47,10 @@ jobs:
         shell: bash
 
       - name: Setup renv
-        uses: r-lib/actions/setup-renv@v2
+        uses: r-lib/actions/setup-renv@a51a8012b0aab7c32ef9d19bf54da93f3254335e
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6.1.1
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_MODEL_DELETION_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Run pre-commit checks
         uses: ccao-data/actions/pre-commit@main

--- a/.github/workflows/tag-model-runs.yaml
+++ b/.github/workflows/tag-model-runs.yaml
@@ -41,10 +41,10 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repo code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e
         with:
           use-public-rspm: true
 
@@ -60,10 +60,10 @@ jobs:
         shell: bash
 
       - name: Setup renv
-        uses: r-lib/actions/setup-renv@v2
+        uses: r-lib/actions/setup-renv@a51a8012b0aab7c32ef9d19bf54da93f3254335e
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6.1.1
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_MODEL_TAGGING_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-suffix: pytest
@@ -26,7 +26,7 @@ jobs:
             python/uv.lock
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: 3.12
 


### PR DESCRIPTION
This PR upgrades all of our third-party GitHub Actions to ensure they are compatible with the [upcoming Node 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

While we're at it, we also switch all of our references to third-party actions to point to immutable releases, so as to protect ourselves from the the ongoing scourge of supply chain attacks against third-party actions. If an action repo is using [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases), we pin to a specific immutable release; otherwise, we pin to the commit hash for the latest release of that action.

Test workflows to confirm these upgrades don't break anything:

- [x] `delete-model-runs`: https://github.com/ccao-data/model-res-avm/actions/runs/26307023259/job/77446272443
- [x] `tag-model-runs`: https://github.com/ccao-data/model-res-avm/actions/runs/26306718515/job/77445233800
- [x] `pre-commit`: https://github.com/ccao-data/model-res-avm/actions/runs/26305469494/job/77441024541?pr=505
- [x] `test`: https://github.com/ccao-data/model-res-avm/actions/runs/26305469527/job/77441024477?pr=505

Connects https://github.com/ccao-data/aws-infrastructure/issues/59.