### PR TITLE
Update to Stratified Test Set

### DIFF
--- a/params.yaml
+++ b/params.yaml
@@ -113,7 +113,7 @@ cv:
   # A stratified test set selects a random percentage of sales, grouped by
   # township, year, and month to add to the test set. If this is set to 0,
   # it has no impact on the pipeline.
-  stratified_prop: 0.00
+  stratified_prop: 0.1
 
   # Number of folds to use for cross-validation. For v-fold CV, the data will be
   # randomly split. For rolling-origin, the data will be split into V chunks by

--- a/params.yaml
+++ b/params.yaml
@@ -113,7 +113,7 @@ cv:
   # A stratified test set selects a random percentage of sales, grouped by
   # township, year, and month to add to the test set. If this is set to 0,
   # it has no impact on the pipeline.
-  stratified_prop: 0.1
+  stratified_prop: 0.00
 
   # Number of folds to use for cross-validation. For v-fold CV, the data will be
   # randomly split. For rolling-origin, the data will be split into V chunks by

--- a/params.yaml
+++ b/params.yaml
@@ -110,9 +110,10 @@ cv:
   # 0.9 means the most recent 10% of sales are used as a test set
   split_prop: 0.9
 
-  # A stratified test set selects a random percentage of sales, grouped by
-  # township, year, and month to add to the test set. If this is set to 0,
-  # it has no impact on the pipeline.
+  # A stratified test set selects a random percentage of sales from those not
+  # already included in the time-split test set, grouped by township, year, and
+  # month to add to the test set. If this is set to 0, it has no impact on the
+  # pipeline.
   stratified_prop: 0.00
 
   # Number of folds to use for cross-validation. For v-fold CV, the data will be

--- a/pipeline/01-train.R
+++ b/pipeline/01-train.R
@@ -44,7 +44,7 @@ split_data <- initial_time_split(
 test <- testing(split_data)
 train <- training(split_data)
 
-# Add a stratified test set which is only included if the value is not set to 0
+# Add a stratified test set if the value of `stratified_prop` is greater than 0.
 # This will take a random selection of sales grouped by township,
 # month, and year and add them to `test`.
 if (params$cv$stratified_prop != 0) {

--- a/pipeline/01-train.R
+++ b/pipeline/01-train.R
@@ -56,11 +56,10 @@ if (params$cv$stratified_prop != 0) {
     initial_split(
       prop = 1 - params$cv$stratified_prop,
       strata = .strat
-    ) %>%
-    select(-.strat)
+    )
 
-  train <- training(strat_split)
-  stratified_sample <- testing(strat_split)
+  train <- training(strat_split) %>% select(-.strat)
+  stratified_sample <- testing(strat_split) %>% select(-.strat)
   test <- bind_rows(test, stratified_sample)
 }
 


### PR DESCRIPTION
Model Run with param > 0 for startified test_set
https://us-east-1.console.aws.amazon.com/s3/object/ccao-model-results-us-east-1?region=us-east-1&prefix=report/year%3D2026/report_type%3Dperformance/2026-06-08-flamboyant-ida.html

https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_test-run_ccao-data-model-res-avm%2Fdefault%2Ffa882191caec4250908fe381418f901c

model run with param = 0 for stratified test set

https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_test-run_ccao-data-model-res-avm%2Fdefault%2F42c457b0b7ab4ef4ac0ae9bbd6445aff

https://us-east-1.console.aws.amazon.com/s3/object/ccao-model-results-us-east-1?region=us-east-1&prefix=report/year%3D2026/report_type%3Dperformance/2026-06-08-objective-tayun.html


Reverts https://github.com/ccao-data/model-res-avm/pull/501/changes/f5f4b75d17eecf770b01a26d92f967dd39e93b0c, which causes an error in the pipeline from
https://github.com/ccao-data/model-res-avm/pull/501