### PR TITLE
Update dbt command in modeling issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/annual-model-checklist.md
+++ b/.github/ISSUE_TEMPLATE/annual-model-checklist.md
@@ -154,7 +154,7 @@ Low priority tasks must be complete eventually, but are not time-sensitive:
     - [ ] Upload the data to the CCAO's public S3 bucket
     - [ ] Make each file in the S3 bucket public using an ACL
     - [ ] Create a link for each file under the appropriate year in the README
-    - [ ] Update the [`model.training_data`](https://github.com/ccao-data/data-architecture/blob/master/dbt/models/model/model.training_data.py) incremental model by running the [`build-and-test-dbt` github workflow][https://github.com/ccao-data/data-architecture/actions/workflows/build_and_test_dbt.yaml] and specifying `model.training_data`
+    - [ ] Update the [`model.training_data`](https://github.com/ccao-data/data-architecture/blob/master/dbt/models/model/model.training_data.py) incremental model by running the [`build-and-test-dbt` github workflow](https://github.com/ccao-data/data-architecture/actions/workflows/build_and_test_dbt.yaml) and specifying `model.training_data`
 - [ ] Take a pass through the condo model README to make sure it's up to date
   - [ ] Double-check that the "Features Used" table includes all features and has no missing descriptions
   - [ ] Make sure the "Prior Models" section has a pointer to last year's model

--- a/.github/ISSUE_TEMPLATE/annual-model-checklist.md
+++ b/.github/ISSUE_TEMPLATE/annual-model-checklist.md
@@ -154,7 +154,7 @@ Low priority tasks must be complete eventually, but are not time-sensitive:
     - [ ] Upload the data to the CCAO's public S3 bucket
     - [ ] Make each file in the S3 bucket public using an ACL
     - [ ] Create a link for each file under the appropriate year in the README
-    - [ ] Update the [`model.training_data`](https://github.com/ccao-data/data-architecture/blob/master/dbt/models/model/model.training_data.py) incremental model by running `dbt run --select model.training_data`
+    - [ ] Update the [`model.training_data`](https://github.com/ccao-data/data-architecture/blob/master/dbt/models/model/model.training_data.py) incremental model by running `dbt run --select model.training_data --target prod`
 - [ ] Take a pass through the condo model README to make sure it's up to date
   - [ ] Double-check that the "Features Used" table includes all features and has no missing descriptions
   - [ ] Make sure the "Prior Models" section has a pointer to last year's model

--- a/.github/ISSUE_TEMPLATE/annual-model-checklist.md
+++ b/.github/ISSUE_TEMPLATE/annual-model-checklist.md
@@ -154,7 +154,7 @@ Low priority tasks must be complete eventually, but are not time-sensitive:
     - [ ] Upload the data to the CCAO's public S3 bucket
     - [ ] Make each file in the S3 bucket public using an ACL
     - [ ] Create a link for each file under the appropriate year in the README
-    - [ ] Update the [`model.training_data`](https://github.com/ccao-data/data-architecture/blob/master/dbt/models/model/model.training_data.py) incremental model by running the `build-and-test-dbt` github workflow and specifying `model.training_data`
+    - [ ] Update the [`model.training_data`](https://github.com/ccao-data/data-architecture/blob/master/dbt/models/model/model.training_data.py) incremental model by running the [`build-and-test-dbt` github workflow][https://github.com/ccao-data/data-architecture/actions/workflows/build_and_test_dbt.yaml] and specifying `model.training_data`
 - [ ] Take a pass through the condo model README to make sure it's up to date
   - [ ] Double-check that the "Features Used" table includes all features and has no missing descriptions
   - [ ] Make sure the "Prior Models" section has a pointer to last year's model

--- a/.github/ISSUE_TEMPLATE/annual-model-checklist.md
+++ b/.github/ISSUE_TEMPLATE/annual-model-checklist.md
@@ -154,7 +154,7 @@ Low priority tasks must be complete eventually, but are not time-sensitive:
     - [ ] Upload the data to the CCAO's public S3 bucket
     - [ ] Make each file in the S3 bucket public using an ACL
     - [ ] Create a link for each file under the appropriate year in the README
-    - [ ] Update the [`model.training_data`](https://github.com/ccao-data/data-architecture/blob/master/dbt/models/model/model.training_data.py) incremental model by running `dbt run --select model.training_data --target prod`
+    - [ ] Update the [`model.training_data`](https://github.com/ccao-data/data-architecture/blob/master/dbt/models/model/model.training_data.py) incremental model by running the `build-and-test-dbt` github workflow and specifying `model.training_data`
 - [ ] Take a pass through the condo model README to make sure it's up to date
   - [ ] Double-check that the "Features Used" table includes all features and has no missing descriptions
   - [ ] Make sure the "Prior Models" section has a pointer to last year's model


### PR DESCRIPTION
The dbt command for updating `model.training_data` needs to point to our `prod` target, but runs up against an s3 delete policy we don't want to disable. We can just use our dbt github workflow to avoid these issues.