### PR TITLE
Remove trace error introduced by `tune` bump and fix upload bug

### DIFF
--- a/params.yaml
+++ b/params.yaml
@@ -20,7 +20,7 @@ run_note: Potential residential baseline with SHAP values, revert DVC path
 toggle:
   # Should the train stage run full cross-validation? Otherwise, the model
   # will be trained with the default hyperparameters specified below
-  cv_enable: true
+  cv_enable: false
 
   # Should SHAP values be calculated for this run in the interpret stage? Can be
   # desirable to save time when testing many models
@@ -31,7 +31,7 @@ toggle:
 
   # Upload all modeling artifacts and results to S3 in the upload stage. Set
   # to false if you are not a CCAO employee
-  upload_enable: false
+  upload_enable: true
 
   # Should the feature report be run, which compares the inputs to the previous
   # year's model inputs?
@@ -96,7 +96,7 @@ input:
   # by year, township, and class to maintain representation across categories
   subset:
     # Whether to use a subset of the training data instead of the full dataset
-    enable: true
+    enable: false
 
     # Fraction of the training data to keep (between 0 and 1)
     fraction: 0.25
@@ -119,7 +119,7 @@ cv:
   # Number of folds to use for cross-validation. For v-fold CV, the data will be
   # randomly split. For rolling-origin, the data will be split into V chunks by
   # time, with each chunk/period calculated automatically
-  num_folds: 2
+  num_folds: 10
 
   # The number of months time-based folds should overlap each other. Only
   # applicable to rolling-origin CV. See https://www.tmwr.org/resampling#rolling
@@ -130,7 +130,7 @@ cv:
   initial_set: 20
 
   # Max number of total search iterations
-  max_iterations: 1
+  max_iterations: 50
 
   # Max number of search iterations without improvement before stopping search
   no_improve: 15

--- a/params.yaml
+++ b/params.yaml
@@ -20,7 +20,7 @@ run_note: Potential residential baseline with SHAP values, revert DVC path
 toggle:
   # Should the train stage run full cross-validation? Otherwise, the model
   # will be trained with the default hyperparameters specified below
-  cv_enable: false
+  cv_enable: true
 
   # Should SHAP values be calculated for this run in the interpret stage? Can be
   # desirable to save time when testing many models
@@ -31,7 +31,7 @@ toggle:
 
   # Upload all modeling artifacts and results to S3 in the upload stage. Set
   # to false if you are not a CCAO employee
-  upload_enable: true
+  upload_enable: false
 
   # Should the feature report be run, which compares the inputs to the previous
   # year's model inputs?
@@ -96,7 +96,7 @@ input:
   # by year, township, and class to maintain representation across categories
   subset:
     # Whether to use a subset of the training data instead of the full dataset
-    enable: false
+    enable: true
 
     # Fraction of the training data to keep (between 0 and 1)
     fraction: 0.25
@@ -119,7 +119,7 @@ cv:
   # Number of folds to use for cross-validation. For v-fold CV, the data will be
   # randomly split. For rolling-origin, the data will be split into V chunks by
   # time, with each chunk/period calculated automatically
-  num_folds: 10
+  num_folds: 2
 
   # The number of months time-based folds should overlap each other. Only
   # applicable to rolling-origin CV. See https://www.tmwr.org/resampling#rolling
@@ -130,7 +130,7 @@ cv:
   initial_set: 20
 
   # Max number of total search iterations
-  max_iterations: 50
+  max_iterations: 1
 
   # Max number of search iterations without improvement before stopping search
   no_improve: 15

--- a/pipeline/01-train.R
+++ b/pipeline/01-train.R
@@ -315,9 +315,14 @@ if (cv_enable) {
   )
 
   # Save tuning results to file. This is a data.frame where each row is one
-  # CV iteration
+  # CV iteration. tune >= 2.0 adds a `trace` column (rlang call stack objects)
+  # to each nested .notes tibble, which arrow cannot serialize, so drop it
+  # before writing. any_of() keeps this a no-op on tune 1.x results
   lgbm_search %>%
     lightsnip::axe_tune_data() %>%
+    mutate(
+      .notes = purrr::map(.notes, ~ dplyr::select(.x, -dplyr::any_of("trace")))
+    ) %>%
     arrow::write_parquet(paths$output$parameter_raw$local)
 
   # Save the parameter ranges searched while tuning

--- a/pipeline/01-train.R
+++ b/pipeline/01-train.R
@@ -319,8 +319,15 @@ if (cv_enable) {
   lgbm_search %>%
     lightsnip::axe_tune_data() %>%
     # Tune added a trace column (rlang stack objects) to each nested .notes
-    # tibble which arrow cannot serialize
-    mutate(.notes = purrr::map(.notes, ~ dplyr::select(.x, -trace))) %>%
+    # tibble which arrow cannot serialize. Flatten each trace to plain text so
+    # the diagnostic content survives into the parquet (a few KB as text, vs
+    # gigabytes of captured environments if left as rlang objects)
+    mutate(.notes = purrr::map(
+      .notes,
+      ~ dplyr::mutate(.x, trace = purrr::map_chr(trace, function(tr) {
+        if (is.null(tr)) NA_character_ else paste(format(tr), collapse = "\n")
+      }))
+    )) %>%
     arrow::write_parquet(paths$output$parameter_raw$local)
 
   # Save the parameter ranges searched while tuning

--- a/pipeline/01-train.R
+++ b/pipeline/01-train.R
@@ -314,19 +314,31 @@ if (cv_enable) {
     )
   )
 
+  # Print any tuning notes (warnings/errors) and their backtraces so they're
+  # visible in CloudWatch logs. Deduplicate by message since iteration 0 logs
+  # one note per initial candidate model
+  tune::collect_notes(lgbm_search) %>%
+    dplyr::distinct(location, type, note, .keep_all = TRUE) %>%
+    purrr::pwalk(function(id, .iter, location, type, note, trace, ...) {
+      cat(sprintf(
+        "---- %s | %s | iter %s | %s ----\n",
+        toupper(type), id, .iter, location
+      ))
+      cat(note, "\n")
+      if (!is.null(trace)) cat(paste(format(trace), collapse = "\n"), "\n")
+    })
+
   # Save tuning results to file. This is a data.frame where each row is one
   # CV iteration
   lgbm_search %>%
     lightsnip::axe_tune_data() %>%
-    # Tune added a trace column (rlang stack objects) to each nested .notes
-    # tibble which arrow cannot serialize. Flatten each trace to plain text so
-    # the diagnostic content survives into the parquet (a few KB as text, vs
-    # gigabytes of captured environments if left as rlang objects)
+    # Drop the trace column tune attaches to each nested .notes tibble: it
+    # holds rlang stack objects that arrow cannot serialize. Traces are
+    # printed above rather than persisted, in part because a fatal error
+    # could take down the pipeline before this file is written or uploaded
     mutate(.notes = purrr::map(
       .notes,
-      ~ dplyr::mutate(.x, trace = purrr::map_chr(trace, function(tr) {
-        if (is.null(tr)) NA_character_ else paste(format(tr), collapse = "\n")
-      }))
+      ~ dplyr::select(.x, -dplyr::any_of("trace"))
     )) %>%
     arrow::write_parquet(paths$output$parameter_raw$local)
 

--- a/pipeline/01-train.R
+++ b/pipeline/01-train.R
@@ -314,28 +314,12 @@ if (cv_enable) {
     )
   )
 
-  # Print any tuning notes (warnings/errors) and their backtraces so they're
-  # visible in CloudWatch logs. Deduplicate by message since iteration 0 logs
-  # one note per initial candidate model
-  tune::collect_notes(lgbm_search) %>%
-    dplyr::distinct(location, type, note, .keep_all = TRUE) %>%
-    purrr::pwalk(function(id, .iter, location, type, note, trace, ...) {
-      cat(sprintf(
-        "---- %s | %s | iter %s | %s ----\n",
-        toupper(type), id, .iter, location
-      ))
-      cat(note, "\n")
-      if (!is.null(trace)) cat(paste(format(trace), collapse = "\n"), "\n")
-    })
-
   # Save tuning results to file. This is a data.frame where each row is one
   # CV iteration
   lgbm_search %>%
     lightsnip::axe_tune_data() %>%
     # Drop the trace column tune attaches to each nested .notes tibble: it
-    # holds rlang stack objects that arrow cannot serialize. Traces are
-    # printed above rather than persisted, in part because a fatal error
-    # could take down the pipeline before this file is written or uploaded
+    # holds rlang stack objects that arrow cannot serialize
     mutate(.notes = purrr::map(
       .notes,
       ~ dplyr::select(.x, -dplyr::any_of("trace"))

--- a/pipeline/01-train.R
+++ b/pipeline/01-train.R
@@ -317,12 +317,10 @@ if (cv_enable) {
   # Save tuning results to file. This is a data.frame where each row is one
   # CV iteration. tune >= 2.0 adds a `trace` column (rlang call stack objects)
   # to each nested .notes tibble, which arrow cannot serialize, so drop it
-  # before writing. any_of() keeps this a no-op on tune 1.x results
+  # before writing
   lgbm_search %>%
     lightsnip::axe_tune_data() %>%
-    mutate(
-      .notes = purrr::map(.notes, ~ dplyr::select(.x, -dplyr::any_of("trace")))
-    ) %>%
+    mutate(.notes = purrr::map(.notes, ~ dplyr::select(.x, -trace))) %>%
     arrow::write_parquet(paths$output$parameter_raw$local)
 
   # Save the parameter ranges searched while tuning

--- a/pipeline/01-train.R
+++ b/pipeline/01-train.R
@@ -315,11 +315,11 @@ if (cv_enable) {
   )
 
   # Save tuning results to file. This is a data.frame where each row is one
-  # CV iteration. tune >= 2.0 adds a `trace` column (rlang call stack objects)
-  # to each nested .notes tibble, which arrow cannot serialize, so drop it
-  # before writing
+  # CV iteration
   lgbm_search %>%
     lightsnip::axe_tune_data() %>%
+    # Tune added a trace column (rlang stack objects) to each nested .notes
+    # tibble which arrow cannot serialize
     mutate(.notes = purrr::map(.notes, ~ dplyr::select(.x, -trace))) %>%
     arrow::write_parquet(paths$output$parameter_raw$local)
 

--- a/pipeline/06-upload.R
+++ b/pipeline/06-upload.R
@@ -102,8 +102,7 @@ if (upload_enable) {
         # to one row per fold and iteration first so the join can't
         # multiply rows
         left_join(
-          read_parquet(paths$output$parameter_raw$local) %>%
-            select(id, .iter, .notes) %>%
+          select(., id, .iter, .notes) %>%
             tidyr::unnest(cols = .notes) %>%
             group_by(id, .iter) %>%
             summarize(

--- a/pipeline/06-upload.R
+++ b/pipeline/06-upload.R
@@ -91,15 +91,32 @@ if (upload_enable) {
       write_parquet(paths$output$parameter_range$s3)
 
     # Clean and unnest the raw parameters data, then write the results to S3
+    parameter_raw <- read_parquet(paths$output$parameter_raw$local)
+
+    # Collapse the nested notes to one row per (fold, iteration) before
+    # joining them onto the metrics. A single key can hold many notes (e.g.
+    # one warning per candidate model in the initial grid), and joining those
+    # directly would fan out the metrics rows, double-counting them in any
+    # downstream aggregation. Identical messages/traces are deduplicated
+    # before pasting; n_notes preserves the raw count
+    notes_collapsed <- parameter_raw %>%
+      select(id, .iter, .notes) %>%
+      tidyr::unnest(cols = .notes) %>%
+      group_by(id, .iter) %>%
+      summarize(
+        n_notes = n(),
+        location = paste(unique(location), collapse = "; "),
+        type = paste(sort(unique(type)), collapse = "; "),
+        notes = paste(unique(note), collapse = "\n---\n"),
+        trace = paste(unique(trace[!is.na(trace)]), collapse = "\n=====\n"),
+        .groups = "drop"
+      )
+
     bind_cols(
-      read_parquet(paths$output$parameter_raw$local) %>%
+      parameter_raw %>%
         tidyr::unnest(cols = .metrics) %>%
         mutate(run_id = !!run_id) %>%
-        left_join(
-          rename(., notes = .notes) %>%
-            tidyr::unnest(cols = notes) %>%
-            rename(notes = note)
-        ) %>%
+        left_join(notes_collapsed, by = c("id", ".iter")) %>%
         select(-.notes) %>%
         rename_with(~ gsub("^\\.", "", .x)) %>%
         tidyr::pivot_wider(names_from = "metric", values_from = "estimate") %>%
@@ -110,8 +127,11 @@ if (upload_enable) {
             "configuration" = "config", "fold_id" = "id"
           ))
         ) %>%
-        relocate(c(location, type, notes), .after = everything()),
-      read_parquet(paths$output$parameter_raw$local) %>%
+        relocate(
+          c(n_notes, location, type, notes, trace),
+          .after = everything()
+        ),
+      parameter_raw %>%
         tidyr::unnest(cols = .extracts) %>%
         tidyr::unnest(cols = .extracts) %>%
         dplyr::select(num_iterations = .extracts)

--- a/pipeline/06-upload.R
+++ b/pipeline/06-upload.R
@@ -93,22 +93,16 @@ if (upload_enable) {
     # Clean and unnest the raw parameters data, then write the results to S3
     parameter_raw <- read_parquet(paths$output$parameter_raw$local)
 
-    # One (fold, iteration) key can hold many notes. The initial grid logs
-    # every candidate model under iteration 0, so one warning per candidate
-    # becomes dozens of notes on that key. Later iterations can also log more
-    # than one warning. Joining notes onto the metrics directly would repeat
-    # each metric row once per note. So first collapse the notes to one row
-    # per key. Each message keeps its location prefix, so a warning can
-    # still be traced back to the candidate model that threw it. Duplicate
-    # messages are dropped
+    # A single (fold, iteration) can hold many notes; iteration 0 alone
+    # logs one per initial candidate model. Collapse them to one row per
+    # key so the join below can't duplicate metric rows, which would fail
+    # the bind_cols against the extracts (mismatched row counts)
     notes_collapsed <- parameter_raw %>%
       select(id, .iter, .notes) %>%
       tidyr::unnest(cols = .notes) %>%
       group_by(id, .iter) %>%
       summarize(
-        # notes must be built before location is overwritten below, since
-        # summarize() makes each new column visible to the expressions after it
-        notes = paste(unique(paste0(location, ": ", note)), collapse = "\n---\n"),
+        notes = paste(unique(note), collapse = "\n---\n"),
         location = paste(unique(location), collapse = "; "),
         type = paste(sort(unique(type)), collapse = "; "),
         trace = paste(unique(trace[!is.na(trace)]), collapse = "\n=====\n"),

--- a/pipeline/06-upload.R
+++ b/pipeline/06-upload.R
@@ -102,7 +102,6 @@ if (upload_enable) {
         notes = paste(unique(note), collapse = "\n---\n"),
         location = paste(unique(location), collapse = "; "),
         type = paste(unique(type), collapse = "; "),
-        trace = paste(unique(trace[!is.na(trace)]), collapse = "\n=====\n"),
         .groups = "drop"
       )
 
@@ -122,10 +121,7 @@ if (upload_enable) {
             "configuration" = "config", "fold_id" = "id"
           ))
         ) %>%
-        relocate(
-          c(location, type, notes, trace),
-          .after = everything()
-        ),
+        relocate(c(location, type, notes), .after = everything()),
       read_parquet(paths$output$parameter_raw$local) %>%
         tidyr::unnest(cols = .extracts) %>%
         tidyr::unnest(cols = .extracts) %>%

--- a/pipeline/06-upload.R
+++ b/pipeline/06-upload.R
@@ -90,27 +90,30 @@ if (upload_enable) {
       relocate(run_id) %>%
       write_parquet(paths$output$parameter_range$s3)
 
-    # A single (fold, iteration) can hold many notes; iteration 0 alone
-    # logs one per initial candidate model. Collapse them to one row per
-    # key so the join below can't duplicate metric rows, which would fail
-    # the bind_cols against the extracts (mismatched row counts)
-    notes_collapsed <- read_parquet(paths$output$parameter_raw$local) %>%
-      select(id, .iter, .notes) %>%
-      tidyr::unnest(cols = .notes) %>%
-      group_by(id, .iter) %>%
-      summarize(
-        notes = paste(unique(note), collapse = "\n---\n"),
-        location = paste(unique(location), collapse = "; "),
-        type = paste(unique(type), collapse = "; "),
-        .groups = "drop"
-      )
-
     # Clean and unnest the raw parameters data, then write the results to S3
     bind_cols(
       read_parquet(paths$output$parameter_raw$local) %>%
         tidyr::unnest(cols = .metrics) %>%
         mutate(run_id = !!run_id) %>%
-        left_join(notes_collapsed, by = c("id", ".iter")) %>%
+        # Each model fit can leave a warning in .notes, but notes don't
+        # record which config produced them. At .iter = 0 each fold holds
+        # all initial configs, so joining the notes unnested would attach
+        # every warning to every metrics row for that fold. Collapse notes
+        # to one row per fold and iteration first so the join can't
+        # multiply rows
+        left_join(
+          read_parquet(paths$output$parameter_raw$local) %>%
+            select(id, .iter, .notes) %>%
+            tidyr::unnest(cols = .notes) %>%
+            group_by(id, .iter) %>%
+            summarize(
+              location = paste(unique(location), collapse = "; "),
+              type = paste(unique(type), collapse = "; "),
+              notes = paste(unique(note), collapse = "; "),
+              .groups = "drop"
+            ),
+          by = c("id", ".iter")
+        ) %>%
         select(-.notes) %>%
         rename_with(~ gsub("^\\.", "", .x)) %>%
         tidyr::pivot_wider(names_from = "metric", values_from = "estimate") %>%

--- a/pipeline/06-upload.R
+++ b/pipeline/06-upload.R
@@ -93,21 +93,25 @@ if (upload_enable) {
     # Clean and unnest the raw parameters data, then write the results to S3
     parameter_raw <- read_parquet(paths$output$parameter_raw$local)
 
-    # Collapse the nested notes to one row per (fold, iteration) before
-    # joining them onto the metrics. A single key can hold many notes (e.g.
-    # one warning per candidate model in the initial grid), and joining those
-    # directly would fan out the metrics rows, double-counting them in any
-    # downstream aggregation. Identical messages/traces are deduplicated
-    # before pasting; n_notes preserves the raw count
+    # One (fold, iteration) key can hold many notes. The initial grid logs
+    # every candidate model under iteration 0, so one warning per candidate
+    # becomes dozens of notes on that key. Later iterations can also log more
+    # than one warning. Joining notes onto the metrics directly would repeat
+    # each metric row once per note. So first collapse the notes to one row
+    # per key. Each message keeps its location prefix, so a warning can
+    # still be traced back to the candidate model that threw it. Duplicate
+    # messages are dropped, and n_notes records the original count
     notes_collapsed <- parameter_raw %>%
       select(id, .iter, .notes) %>%
       tidyr::unnest(cols = .notes) %>%
       group_by(id, .iter) %>%
       summarize(
         n_notes = n(),
+        # notes must be built before location is overwritten below, since
+        # summarize() makes each new column visible to the expressions after it
+        notes = paste(unique(paste0(location, ": ", note)), collapse = "\n---\n"),
         location = paste(unique(location), collapse = "; "),
         type = paste(sort(unique(type)), collapse = "; "),
-        notes = paste(unique(note), collapse = "\n---\n"),
         trace = paste(unique(trace[!is.na(trace)]), collapse = "\n=====\n"),
         .groups = "drop"
       )

--- a/pipeline/06-upload.R
+++ b/pipeline/06-upload.R
@@ -90,27 +90,25 @@ if (upload_enable) {
       relocate(run_id) %>%
       write_parquet(paths$output$parameter_range$s3)
 
-    # Clean and unnest the raw parameters data, then write the results to S3
-    parameter_raw <- read_parquet(paths$output$parameter_raw$local)
-
     # A single (fold, iteration) can hold many notes; iteration 0 alone
     # logs one per initial candidate model. Collapse them to one row per
     # key so the join below can't duplicate metric rows, which would fail
     # the bind_cols against the extracts (mismatched row counts)
-    notes_collapsed <- parameter_raw %>%
+    notes_collapsed <- read_parquet(paths$output$parameter_raw$local) %>%
       select(id, .iter, .notes) %>%
       tidyr::unnest(cols = .notes) %>%
       group_by(id, .iter) %>%
       summarize(
         notes = paste(unique(note), collapse = "\n---\n"),
         location = paste(unique(location), collapse = "; "),
-        type = paste(sort(unique(type)), collapse = "; "),
+        type = paste(unique(type), collapse = "; "),
         trace = paste(unique(trace[!is.na(trace)]), collapse = "\n=====\n"),
         .groups = "drop"
       )
 
+    # Clean and unnest the raw parameters data, then write the results to S3
     bind_cols(
-      parameter_raw %>%
+      read_parquet(paths$output$parameter_raw$local) %>%
         tidyr::unnest(cols = .metrics) %>%
         mutate(run_id = !!run_id) %>%
         left_join(notes_collapsed, by = c("id", ".iter")) %>%
@@ -128,7 +126,7 @@ if (upload_enable) {
           c(location, type, notes, trace),
           .after = everything()
         ),
-      parameter_raw %>%
+      read_parquet(paths$output$parameter_raw$local) %>%
         tidyr::unnest(cols = .extracts) %>%
         tidyr::unnest(cols = .extracts) %>%
         dplyr::select(num_iterations = .extracts)

--- a/pipeline/06-upload.R
+++ b/pipeline/06-upload.R
@@ -100,13 +100,12 @@ if (upload_enable) {
     # each metric row once per note. So first collapse the notes to one row
     # per key. Each message keeps its location prefix, so a warning can
     # still be traced back to the candidate model that threw it. Duplicate
-    # messages are dropped, and n_notes records the original count
+    # messages are dropped
     notes_collapsed <- parameter_raw %>%
       select(id, .iter, .notes) %>%
       tidyr::unnest(cols = .notes) %>%
       group_by(id, .iter) %>%
       summarize(
-        n_notes = n(),
         # notes must be built before location is overwritten below, since
         # summarize() makes each new column visible to the expressions after it
         notes = paste(unique(paste0(location, ": ", note)), collapse = "\n---\n"),
@@ -132,7 +131,7 @@ if (upload_enable) {
           ))
         ) %>%
         relocate(
-          c(n_notes, location, type, notes, trace),
+          c(location, type, notes, trace),
           .after = everything()
         ),
       parameter_raw %>%


### PR DESCRIPTION
## Running into the error

I stumbled upon this bug while attempting to confirm the [upload stage warning bug](https://github.com/ccao-data/model-condo-avm/pull/170#discussion_r3633712681) discovered in the condo `mse_cov` PR.

My original objective was to reproduce this bug for the res model. First, I subsetted the CV hyperparam search and the training data to attempt to reproduce the `mse_cov` upload bug with less CV batch spend, but I was met with a different error - [error message in cloudwatch](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_mwagner-verify-cv-error_ccao-data-model-res-avm%2Fdefault%2Fab990654c96444f9b17480ba0c0a28ec)

```
  | 2026-08-19T20:47:30.807Z | ✓ Estimating performance
  | 2026-08-19T20:47:30.848Z | ♥ Newest results: rmse=0.2871 (+/-0.000489)
  | 2026-08-19T20:47:30.851Z | Error: Cannot infer type from vector
  | 2026-08-19T20:47:30.851Z | Execution halted
  | 2026-08-19T20:47:31.258Z | ERROR: failed to reproduce 'train': failed to run: Rscript pipeline/01-train.R, exited with 1
```

Then, I kicked off a CV run off of master in an effort to see if this was a result of my CV shirink/subset, and the error was reproduced on main: [error message in cloudwatch](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/ccao-data-model-res-avm%2Fdefault%2F6a9cc212bed741d784adda40be9782c7)

```
  | 2026-08-20T07:31:11.179Z | ! No improvement for 15 iterations; returning current results.
  | 2026-08-20T07:31:11.182Z | Error: Cannot infer type from vector
  | 2026-08-20T07:31:11.183Z | Execution halted
  | 2026-08-20T07:31:12.153Z | ERROR: failed to reproduce 'train': failed to run: Rscript pipeline/01-train.R, exited with 1
```

## Root cause

The problem is that there is a new trace column persisted in our new tune version. #533 upgraded `tune` from 1.x to 2.1.0. `tune` 2.x added a `trace` column to the `.notes` tibbles inside tuning results.
- Changelog - https://tune.tidymodels.org/news/index.html#tune-200
- PR: https://github.com/tidymodels/tune/pull/879


The column holds rlang call-stack objects, one per captured warning. At the end of CV, the train stage writes the raw tuning results to parquet:

```r
lgbm_search %>%
  lightsnip::axe_tune_data() %>%
  arrow::write_parquet(paths$output$parameter_raw$local)
```

Arrow has no serialization for a list of call stacks, so the write fails with `Cannot infer type from vector`. The crash happens after tuning completes.

Any warning captured during tuning triggers the bug. The `mse_cov` objective guarantees warnings, because `predict.lgb.Booster()` warns once per predict call for custom objectives.

## Verify solution works

[This run](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Fbatch%2Fjob/log-events/z_ci_mwagner-fix-trace-bug_ccao-data-model-res-avm%2Fdefault%2F07bc903b654440ef9e1fe8f974ed57c1) with the fix successfully passes the train stage (but fails at the upload stage because that fix is being handled [here](https://github.com/ccao-data/model-res-avm/pull/545), not in this PR).

Closes #539 and #552 
