### PR TITLE
Persist raw logged prices and predictions when we train in log space

### DIFF
--- a/pipeline/01-train.R
+++ b/pipeline/01-train.R
@@ -435,11 +435,22 @@ walk2(
         )$.pred)
       )
 
+    # Preserve the log-scale outcome and prediction alongside their dollar
+    # equivalents. NA when the transform is off, since no log-space model
+    # output exists in that case
     if (log_transform_enable) {
       preds <- preds %>%
         mutate(
+          pred_card_initial_fmv_log = pred_card_initial_fmv,
+          meta_sale_price_log = meta_sale_price,
           pred_card_initial_fmv = exp(pred_card_initial_fmv),
           meta_sale_price = meta_sale_price_original
+        )
+    } else {
+      preds <- preds %>%
+        mutate(
+          pred_card_initial_fmv_log = NA_real_,
+          meta_sale_price_log = NA_real_
         )
     }
 
@@ -451,8 +462,10 @@ walk2(
           "prior_far_tot" = params$ratio_study$far_column,
           "prior_near_tot" = params$ratio_study$near_column
         )),
-        pred_card_initial_fmv, pred_card_initial_fmv_lin,
-        meta_sale_price, meta_sale_date, meta_sale_document_num
+        pred_card_initial_fmv, pred_card_initial_fmv_log,
+        pred_card_initial_fmv_lin,
+        meta_sale_price, meta_sale_price_log,
+        meta_sale_date, meta_sale_document_num
       ) %>%
       # Prior year values are AV, not FMV.
       # Multiply by 10 to get FMV for residential

--- a/pipeline/02-assess.R
+++ b/pipeline/02-assess.R
@@ -66,10 +66,18 @@ assessment_card_data_pred <- read_parquet(paths$input$assessment$local) %>%
   ) %>%
   select(-og_char_bldg_sf)
 
-# Exponentiate predictions back to raw dollar scale
+# Exponentiate predictions back to raw dollar scale, preserving the raw
+# log-scale prediction alongside its dollar equivalent. NA when the transform
+# is off, since no log-space model output exists in that case
 if (log_transform_enable) {
   assessment_card_data_pred <- assessment_card_data_pred %>%
-    mutate(pred_card_initial_fmv = exp(pred_card_initial_fmv))
+    mutate(
+      pred_card_initial_fmv_log = pred_card_initial_fmv,
+      pred_card_initial_fmv = exp(pred_card_initial_fmv)
+    )
+} else {
+  assessment_card_data_pred <- assessment_card_data_pred %>%
+    mutate(pred_card_initial_fmv_log = NA_real_)
 }
 
 
@@ -324,7 +332,8 @@ char_vars <- char_vars[!char_vars %in% c("char_apts", "char_recent_renovation")]
 assessment_card_data_merged %>%
   select(
     meta_year, meta_pin, meta_class, meta_card_num, meta_card_pct_total_fmv,
-    meta_complex_id, pred_card_initial_fmv, pred_card_final_fmv, char_class,
+    meta_complex_id, pred_card_initial_fmv, pred_card_initial_fmv_log,
+    pred_card_final_fmv, char_class,
     all_of(params$model$predictor$all), township_code
   ) %>%
   mutate(

--- a/pipeline/02-assess.R
+++ b/pipeline/02-assess.R
@@ -66,9 +66,8 @@ assessment_card_data_pred <- read_parquet(paths$input$assessment$local) %>%
   ) %>%
   select(-og_char_bldg_sf)
 
-# Exponentiate predictions back to raw dollar scale, preserving the raw
-# log-scale prediction alongside its dollar equivalent. NA when the transform
-# is off, since no log-space model output exists in that case
+# Exponentiate predictions back to raw dollar scale, preserving
+# original log scale
 if (log_transform_enable) {
   assessment_card_data_pred <- assessment_card_data_pred %>%
     mutate(


### PR DESCRIPTION
This PR preserves logged price and prediction data for easier debuggging/troubleshooting/eda when we run the model with log transform active.

Summary of data changes:
| Athena table | New columns | Count |
| --- | --- | --- |
| model.test_card | `meta_sale_price_log`, `pred_card_initial_fmv_log` | 2 |
| model.train_card | `meta_sale_price_log`, `pred_card_initial_fmv_log` | 2 |
| model.assessment_card | `pred_card_initial_fmv_log` | 1 |

In the case of a non-logged model, these new columns values will be NA.

Closes #528 