### PR TITLE
Bump vcpu and ram to take advantage of m8i

### DIFF
--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -90,8 +90,9 @@ jobs:
       # required in order to allow the reusable called workflow to push to
       # GitHub Container Registry
       packages: write
-    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@main
+    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@mwagner/test-ec2-hardware-bump
     with:
+      ref: mwagner/test-ec2-hardware-bump
       command: ${{ needs.parse-command.outputs.command }}
       backend: "ec2"
       vcpu: "40"

--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -90,9 +90,8 @@ jobs:
       # required in order to allow the reusable called workflow to push to
       # GitHub Container Registry
       packages: write
-    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@mwagner/test-ec2-hardware-bump
+    uses: ccao-data/actions/.github/workflows/build-and-run-batch-job.yaml@main
     with:
-      ref: mwagner/test-ec2-hardware-bump
       command: ${{ needs.parse-command.outputs.command }}
       backend: "ec2"
       vcpu: "48"

--- a/.github/workflows/build-and-run-model.yaml
+++ b/.github/workflows/build-and-run-model.yaml
@@ -95,8 +95,8 @@ jobs:
       ref: mwagner/test-ec2-hardware-bump
       command: ${{ needs.parse-command.outputs.command }}
       backend: "ec2"
-      vcpu: "40"
-      memory: "158000"
+      vcpu: "48"
+      memory: "180000"
       # Maximum pipeline runtime. This is slightly below 6 hours, which
       # is the maximum length of any single GitHub Actions job
       role-duration-seconds: 21000


### PR DESCRIPTION
In https://github.com/ccao-data/actions/pull/47 we discovered that swapping instances gives us a 2x speed up on batch for a similar cost. This PR bumps the resources to take advantage from the hardware bump we get from switch from m4 to m8i.